### PR TITLE
[DO NOT MERGE] pitzer version

### DIFF
--- a/form.yml
+++ b/form.yml
@@ -1,5 +1,5 @@
----
-cluster: "owens"
+--- 
+cluster: "pitzer"
 form:
   - bc_account
   - bc_num_hours
@@ -15,7 +15,7 @@ attributes:
       Number of cores on node type (4 GB per core unless requesting whole
       node). Leave blank if requesting full node.
     min: 1
-    max: 28
+    max: 40
     step: 1
   bc_account:
     label: "Project"
@@ -24,19 +24,20 @@ attributes:
     widget: select
     label: "Node type"
     help: |
-      - **any** - (*1-28 cores*) Use any available Owens node. This reduces the
-        wait time as there are no node requirements.
-      - **gpu** - (*1-28 cores*) Use an Owens node that has an [NVIDIA Tesla P100
-        GPU] and loads the [CUDA] 8.0.44 module. There are 160 of these nodes
-        on Owens.
-      - **hugemem** - (*48 cores*) Use an Owens node that has 1.5TB of
-        available RAM as well as 48 cores. There are 16 of these nodes on
-        Owens.
-      - **debug** - (*1-28 cores*) For short sessions (= 1 hour) the debug queue
+      - **any** - (*1-40 cores*) Chooses anyone of the available Pitzer nodes.
+        This reduces the wait time as you have no requirements. Standard Pitzer
+        nodes have 192GB of memory.
+      - **gpu** - (*1-40 cores*) This node includes two [NVIDIA Tesla V100 GPUs]
+        and loads the [CUDA] 9.2.88 module. This node has 384GB of memory.
+        There are currently only 32 of these nodes on Pitzer.
+      - **hugemem** - (*80 cores*) This Pitzer node has 3TB of memory as
+        well as 80 cores. There are only 4 of these nodes on Pitzer. A
+        reservation may be required to use this node.
+      - **debug** - (*1-40 cores*) For short sessions (= 1 hour) the debug queue
         will have the shortest wait time. This is only accessible during 8AM -
-        6PM, Monday - Friday. There are 6 of these nodes on Owens.
-
-      [NVIDIA Tesla P100 GPU]: http://www.nvidia.com/object/tesla-p100.html
+        6PM, Monday - Friday. There are 6 of these nodes on Pitzer.
+        
+      [NVIDIA Tesla V100 GPUs]: http://www.nvidia.com/object/tesla-p100.html
       [CUDA]: https://developer.nvidia.com/cuda-zone
     options:
       - [ "any",     "any"     ]

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,12 +1,13 @@
 ---
-name: Jupyter Notebook
+name: Jupyter Notebook (Pitzer)
 category: Interactive Apps
 subcategory: Servers
 role: batch_connect
 description: |
-  This app will launch a [Jupyter Notebook] server using [Python] on the [Owens
-  cluster].
+  This app will launch a [Jupyter Notebook] server using [Python] on the [Pitzer cluster].
+    <div class="alert alert-info"><strong>Julia kernels are not available yet on Pitzer. If you need assistence contact <a href="mailto:oschelp@osc.edu">oschelp@osc.edu</a>.</strong>
+  </div>
 
   [Jupyter Notebook]: https://jupyter.org/
   [Python]: https://www.python.org/
-  [Owens cluster]: https://www.osc.edu/resources/technical_support/supercomputers/owens
+  [Pitzer cluster]: https://www.osc.edu/supercomputing/computing/pitzer

--- a/submit.yml.erb
+++ b/submit.yml.erb
@@ -1,10 +1,10 @@
 <%-
-  ppn   = num_cores.blank? ? 28 : num_cores.to_i
+  ppn   = num_cores.blank? ? 40 : num_cores.to_i
   props = case node_type
           when "gpu"
             ":ppn=#{ppn}:gpus=1"
           when "hugemem"
-            ":ppn=48"
+            ":ppn=80"
           else
             ":ppn=#{ppn}"
           end

--- a/template/before.sh.erb
+++ b/template/before.sh.erb
@@ -22,7 +22,7 @@ umask 077
 cat > "${CONFIG_FILE}" << EOL
 c.JupyterApp.config_file_name = 'ondemand_config'
 c.KernelSpecManager.ensure_native_kernel = False
-c.NotebookApp.ip = '*'
+c.NotebookApp.ip = '0.0.0.0'
 c.NotebookApp.port = ${port}
 c.NotebookApp.port_retries = 0
 c.NotebookApp.password = u'sha1:${SALT}:${PASSWORD_SHA1}'

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -6,8 +6,8 @@
   wrapper_log = session.staged_root.join("launch_wrapper.log")
 
   kernels = {
-    python36: {
-      display_name: "Python 3.6 [python/3.6#{" cuda/8.0.44" if cuda}]",
+    python36conda: {
+      display_name: "Python 3.6 (Conda 5.2) [python/3.6-conda5.2#{" cuda/9.2.88" if cuda}]",
       language: "python",
       argv: [
         wrapper,
@@ -18,41 +18,11 @@
         "{connection_file}"
       ],
       env: {
-        MODULES: "python/3.6#{" cuda/8.0.44" if cuda}"
-      }
-    },
-    python35: {
-      display_name: "Python 3.5 [python/3.5#{" cuda/8.0.44" if cuda}]",
-      language: "python",
-      argv: [
-        wrapper,
-        "python",
-        "-m",
-        "ipykernel",
-        "-f",
-        "{connection_file}"
-      ],
-      env: {
-        MODULES: "python/3.5#{" cuda/8.0.44" if cuda}"
-      }
-    },
-    python27: {
-      display_name: "Python 2.7 [python/2.7#{" cuda/8.0.44" if cuda}]",
-      language: "python",
-      argv: [
-        wrapper,
-        "python",
-        "-m",
-        "ipykernel",
-        "-f",
-        "{connection_file}"
-      ],
-      env: {
-        MODULES: "python/2.7#{" cuda/8.0.44" if cuda}"
+        MODULES: "python/3.6-conda5.2#{" cuda/9.2.88" if cuda}"
       }
     },
     python27conda: {
-      display_name: "Python 2.7 (Conda 5.2) [python/2.7#{" cuda/8.0.44" if cuda}]",
+      display_name: "Python 2.7 (Conda 5.2) [python/2.7-conda5.2#{" cuda/9.2.88" if cuda}]",
       language: "python",
       argv: [
         wrapper,
@@ -63,55 +33,7 @@
         "{connection_file}"
       ],
       env: {
-        MODULES: "python/2.7-conda5.2#{" cuda/8.0.44" if cuda}"
-      }
-    },
-    julia051: {
-      display_name: "Julia 0.5.1 [julia/0.5.1#{" cuda/8.0.44" if cuda}]",
-      language: "julia",
-      argv: [
-        wrapper,
-        "julia",
-        "-i",
-        "--startup-file=yes",
-        "--color=yes",
-        "/usr/local/julia/0.5.1/share/julia/site/v0.5/IJulia/src/kernel.jl",
-        "{connection_file}"
-      ],
-      env: {
-        MODULES: "julia/0.5.1#{" cuda/8.0.44" if cuda}"
-      }
-    },
-    julia064: {
-      display_name: "Julia 0.6.4 [julia/0.6.4#{" cuda/8.0.44" if cuda}]",
-      language: "julia",
-      argv: [
-        wrapper,
-        "julia",
-        "-i",
-        "--startup-file=yes",
-        "--color=yes",
-        "/usr/local/julia/0.6.4/site/v0.6/IJulia/src/kernel.jl",
-        "{connection_file}"
-      ],
-      env: {
-        MODULES: "julia/0.6.4#{" cuda/8.0.44" if cuda}"
-      }
-    },
-    julia100: {
-      display_name: "Julia 1.0.0 [julia/1.0.0#{" cuda/8.0.44" if cuda}]",
-      language: "julia",
-      argv: [
-        wrapper,
-        "julia",
-        "-i",
-        "--startup-file=yes",
-        "--color=yes",
-        "/usr/local/julia/1.0.0/site/packages/IJulia/9RcVi/src/kernel.jl",
-        "{connection_file}"
-      ],
-      env: {
-        MODULES: "julia/1.0.0#{" cuda/8.0.44" if cuda}"
+        MODULES: "python/2.7-conda5.2#{" cuda/9.2.88" if cuda}"
       }
     },
   }
@@ -196,8 +118,8 @@ echo "TTT - $(date)"
 cd "${NOTEBOOK_ROOT}"
 
 # Setup Jupyter Notebook environment
-module use $MODULEPATH_ROOT/project/ondemand
-module load jupyter/python3.5
+module use /apps/lmodfiles/project/ondemand
+module load jupyter/python3.6
 module list
 echo "TTT - $(date)"
 


### PR DESCRIPTION
## Jupyter notebook on Pitzer

### Three kernels available: 
<img width="1250" alt="screen shot 2018-10-17 at 6 11 06 pm" src="https://user-images.githubusercontent.com/22674713/47119785-368dd100-d23a-11e8-8b1e-8a3f12e29bab.png">

### Temporary alert:
<img width="633" alt="screen shot 2018-10-17 at 6 28 45 pm" src="https://user-images.githubusercontent.com/22674713/47119843-8371a780-d23a-11e8-9237-227cae689c76.png">

### Issue:
Need Pitzer debug node information. The current version is using description from Owens.
```
       **debug** - (*1-40 cores*) For short sessions (= 1 hour) the debug queue
        will have the shortest wait time. This is only accessible during 8AM -
        6PM, Monday - Friday. There are 6 of these nodes on Pitzer.
```

