### PR TITLE
Add option to specify version of Jupyter module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 - Option to launch JupyterLab instead of Jupyter Notebook
+- Option to specify version of Jupyter/JupyterLab module
 
 ## [0.9.0] - 2018-09-20
 ### Added

--- a/form.yml
+++ b/form.yml
@@ -6,6 +6,7 @@ form:
   - bc_num_hours
   - node_type
   - num_cores
+  - version
   - bc_email_on_started
 attributes:
   jupyterlab_switch:
@@ -49,3 +50,9 @@ attributes:
       - [ "gpu",     "gpu"     ]
       - [ "hugemem", "hugemem" ]
       - [ "debug",   "debug"   ]
+  version:
+    widget: select
+    label: "Jupyter Version"
+    help: "This defines the version of Jupyter you want to load."
+    options:
+      - [ "default", "jupyter/python3.5" ]

--- a/form.yml
+++ b/form.yml
@@ -50,9 +50,4 @@ attributes:
       - [ "gpu",     "gpu"     ]
       - [ "hugemem", "hugemem" ]
       - [ "debug",   "debug"   ]
-  version:
-    widget: select
-    label: "Jupyter Version"
-    help: "This defines the version of Jupyter you want to load."
-    options:
-      - [ "default", "jupyter/python3.5" ]
+  version: "jupyter/python3.5" 

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -197,7 +197,7 @@ cd "${NOTEBOOK_ROOT}"
 
 # Setup Jupyter environment
 module use $MODULEPATH_ROOT/project/ondemand
-module load jupyter/python3.5
+module load <%= !defined?(context.version) || context.version.nil? ? "jupyter/python3.5" : context.version %>
 module list
 echo "TTT - $(date)"
 

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -197,7 +197,7 @@ cd "${NOTEBOOK_ROOT}"
 
 # Setup Jupyter environment
 module use $MODULEPATH_ROOT/project/ondemand
-module load <%= !defined?(context.version) || context.version.nil? ? "jupyter/python3.5" : context.version %>
+module load <%= context.version %>
 module list
 echo "TTT - $(date)"
 


### PR DESCRIPTION
This pull request adds the ability to specify the version of the Jupyter module at the form level. This allows teams that do not install a standalone Jupyter module (i.e. Jupyter is bundled with `python-anaconda`) to still be able to use the Jupyter Interactive App. This is similar to what is being done for the [MATLAB Interactive App](https://github.com/OSC/bc_osc_matlab).

I maintained default behavior in the case where`version` is not defined or is `nil` by defaulting to the original `jupyter/python3.5` module. 