### PR TITLE
Add CUDA Select

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Option to launch JupyterLab instead of Jupyter Notebook
 - Option to specify version of Jupyter/JupyterLab module
+- Add form.js to sync node type selection with options for core count and cuda
+  options
 
 ## [0.9.0] - 2018-09-20
 ### Added

--- a/form.js
+++ b/form.js
@@ -1,0 +1,109 @@
+'use strict'
+
+/**
+ * Fix num cores, allowing blanks to remain
+ */
+function fix_num_cores() {
+  let node_type_input = $('#batch_connect_session_context_node_type');
+  let node_type = node_type_input.val();
+  let num_cores_input = $('#batch_connect_session_context_num_cores');
+
+  if(num_cores_input.val() === '') {
+    return;
+  }
+
+  if(node_type === 'hugemem') {
+    set_ppn_owens_hugemem(num_cores_input);
+  } else {
+    set_ppn_owens_regular(num_cores_input);
+  }
+}
+
+/**
+ * Sets the PPN limits available for Owens hugemem nodes.
+ *
+ * hugemem reservations are always assigned the full node
+ *
+ * @param      {element}  num_cores_input  The input for num_cores
+ */
+function set_ppn_owens_hugemem(num_cores_input) {
+  const NUM_CORES = 48;
+  num_cores_input.attr('max', NUM_CORES);
+  num_cores_input.attr('min', NUM_CORES);
+  num_cores_input.val(NUM_CORES);
+}
+
+/**
+ * Sets the PPN limits available for non hugemem Owens nodes.
+ *
+ * @param      {element}  num_cores_input  The input for num_cores
+ */
+function set_ppn_owens_regular(num_cores_input) {
+  const NUM_CORES = 28;
+  num_cores_input.attr('max', NUM_CORES);
+  num_cores_input.attr('min', 0);
+  num_cores_input.val(Math.min(NUM_CORES, num_cores_input.val()));
+}
+
+/**
+ * Toggle the visibilty of a form group
+ *
+ * @param      {string}    form_id  The form identifier
+ * @param      {boolean}   show     Whether to show or hide
+ */
+function toggle_visibilty_of_form_group(form_id, show) {
+  let form_element = $(form_id);
+  let parent = form_element.parent();
+
+  if(show) {
+    parent.show();
+  } else {
+    form_element.val('');
+    parent.hide();
+  }
+}
+
+/**
+ * Toggle the visibilty of the CUDA select
+ *
+ * GPU: visible
+ * *: hidden
+ */
+function toggle_cuda_version_visibility() {
+  let cuda_version = $('#batch_connect_session_context_cuda_version');
+  let node_type_input = $('#batch_connect_session_context_node_type');
+  let show = (node_type_input.val() === 'gpu');
+
+  toggle_visibilty_of_form_group(
+    '#batch_connect_session_context_cuda_version',
+    show
+  );
+}
+
+/**
+ * Sets the change handler for the node_type select.
+ */
+function set_node_type_change_handler() {
+  let node_type_input = $('#batch_connect_session_context_node_type');
+  node_type_input.change(node_type_change_hander);
+}
+
+/**
+ * Update UI when node_type changes
+ */
+function node_type_change_hander() {
+  fix_num_cores();
+  toggle_cuda_version_visibility();
+}
+
+/**
+ * Main
+ */
+$(document).ready(function() {
+  // Set controls to align with the values of the last session context
+  fix_num_cores();
+  toggle_cuda_version_visibility();
+
+  // Install event handlers
+  set_node_type_change_handler();
+});

--- a/form.yml
+++ b/form.yml
@@ -29,19 +29,18 @@ attributes:
     label: "Project"
     help: "You can leave this blank if **not** in multiple projects."
   cuda_version:
-      value: ''
-      widget: "select"
-      label: "CUDA Version"
-      help: |
-        CUDA is Nvidia's GPU-specific parallel computing framework. A GPU node
-        is required to make use of this functionality.
-      options:
-        - [ "cuda/8.0.44",    "cuda/8.0.44"   ]
-        - [ "cuda/8.0.61",    "cuda/8.0.61"   ]
-        - [ "cuda/9.0.176",   "cuda/9.0.176"  ]
-        - [ "cuda/9.1.85",    "cuda/9.1.85"   ]
-        - [ "cuda/9.2.88",    "cuda/9.2.88"   ]
-        - [ "cuda/10.0.130",  "cuda/10.0.130" ]
+    widget: "select"
+    label: "CUDA Version"
+    help: |
+      CUDA is Nvidia's GPU-specific parallel computing framework. A GPU node
+      is required to make use of this functionality.
+    options:
+      - [ "cuda/8.0.44",    "cuda/8.0.44"   ]
+      - [ "cuda/8.0.61",    "cuda/8.0.61"   ]
+      - [ "cuda/9.0.176",   "cuda/9.0.176"  ]
+      - [ "cuda/9.1.85",    "cuda/9.1.85"   ]
+      - [ "cuda/9.2.88",    "cuda/9.2.88"   ]
+      - [ "cuda/10.0.130",  "cuda/10.0.130" ]
   node_type:
     widget: select
     label: "Node type"
@@ -49,7 +48,7 @@ attributes:
       - **any** - (*1-28 cores*) Use any available Owens node. This reduces the
         wait time as there are no node requirements.
       - **gpu** - (*1-28 cores*) Use an Owens node that has an [NVIDIA Tesla P100
-        GPU] and loads the [CUDA] 8.0.44 module. There are 160 of these nodes
+        GPU] and loads the requested [CUDA] module. There are 160 of these nodes
         on Owens.
       - **hugemem** - (*48 cores*) Use an Owens node that has 1.5TB of
         available RAM as well as 48 cores. There are 16 of these nodes on
@@ -61,8 +60,28 @@ attributes:
       [NVIDIA Tesla P100 GPU]: http://www.nvidia.com/object/tesla-p100.html
       [CUDA]: https://developer.nvidia.com/cuda-zone
     options:
-      - [ "any",     "any"     ]
-      - [ "gpu",     "gpu"     ]
-      - [ "hugemem", "hugemem" ]
-      - [ "debug",   "debug"   ]
+      - [
+          "any",     "any",
+          data-min-ppn: 0,
+          data-max-ppn: 28,
+          data-can-show-cuda: false
+        ]
+      - [
+          "gpu",     "gpu",
+          data-min-ppn: 0,
+          data-max-ppn: 28,
+          data-can-show-cuda: true
+        ]
+      - [
+          "hugemem", "hugemem",
+          data-min-ppn: 48,
+          data-max-ppn: 48,
+          data-can-show-cuda: false
+        ]
+      - [
+          "debug",   "debug",
+          data-min-ppn: 0,
+          data-max-ppn: 28,
+          data-can-show-cuda: false
+        ]
   version: "jupyter/python3.5" 

--- a/form.yml
+++ b/form.yml
@@ -5,6 +5,7 @@ form:
   - jupyterlab_switch
   - bc_num_hours
   - node_type
+  - cuda_version
   - num_cores
   - version
   - bc_email_on_started
@@ -27,6 +28,20 @@ attributes:
   bc_account:
     label: "Project"
     help: "You can leave this blank if **not** in multiple projects."
+  cuda_version:
+      value: ''
+      widget: "select"
+      label: "CUDA Version"
+      help: |
+        CUDA is Nvidia's GPU-specific parallel computing framework. A GPU node
+        is required to make use of this functionality.
+      options:
+        - [ "cuda/8.0.44",    "cuda/8.0.44"   ]
+        - [ "cuda/8.0.61",    "cuda/8.0.61"   ]
+        - [ "cuda/9.0.176",   "cuda/9.0.176"  ]
+        - [ "cuda/9.1.85",    "cuda/9.1.85"   ]
+        - [ "cuda/9.2.88",    "cuda/9.2.88"   ]
+        - [ "cuda/10.0.130",  "cuda/10.0.130" ]
   node_type:
     widget: select
     label: "Node type"

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 
 <%-
-  cuda = context.node_type == "gpu"
+  cuda = (context.node_type == "gpu") ? context.cuda_version : ""
   wrapper = session.staged_root.join("launch_wrapper.sh")
   wrapper_log = session.staged_root.join("launch_wrapper.log")
 
   kernels = {
     python36: {
-      display_name: "Python 3.6 [python/3.6#{" cuda/8.0.44" if cuda}]",
+      display_name: "Python 3.6 [python/3.6 #{cuda}]",
       language: "python",
       argv: [
         wrapper,
@@ -18,11 +18,11 @@
         "{connection_file}"
       ],
       env: {
-        MODULES: "python/3.6#{" cuda/8.0.44" if cuda}"
+        MODULES: "python/3.6 #{cuda}"
       }
     },
     python35: {
-      display_name: "Python 3.5 [python/3.5#{" cuda/8.0.44" if cuda}]",
+      display_name: "Python 3.5 [python/3.5 #{cuda}]",
       language: "python",
       argv: [
         wrapper,
@@ -33,11 +33,11 @@
         "{connection_file}"
       ],
       env: {
-        MODULES: "python/3.5#{" cuda/8.0.44" if cuda}"
+        MODULES: "python/3.5 #{cuda}"
       }
     },
     python27: {
-      display_name: "Python 2.7 [python/2.7#{" cuda/8.0.44" if cuda}]",
+      display_name: "Python 2.7 [python/2.7 #{cuda}]",
       language: "python",
       argv: [
         wrapper,
@@ -48,11 +48,11 @@
         "{connection_file}"
       ],
       env: {
-        MODULES: "python/2.7#{" cuda/8.0.44" if cuda}"
+        MODULES: "python/2.7 #{cuda}"
       }
     },
     python27conda: {
-      display_name: "Python 2.7 (Conda 5.2) [python/2.7#{" cuda/8.0.44" if cuda}]",
+      display_name: "Python 2.7 (Conda 5.2) [python/2.7 #{cuda}]",
       language: "python",
       argv: [
         wrapper,
@@ -63,11 +63,11 @@
         "{connection_file}"
       ],
       env: {
-        MODULES: "python/2.7-conda5.2#{" cuda/8.0.44" if cuda}"
+        MODULES: "python/2.7-conda5.2 #{cuda}"
       }
     },
     julia051: {
-      display_name: "Julia 0.5.1 [julia/0.5.1#{" cuda/8.0.44" if cuda}]",
+      display_name: "Julia 0.5.1 [julia/0.5.1 #{cuda}]",
       language: "julia",
       argv: [
         wrapper,
@@ -79,11 +79,11 @@
         "{connection_file}"
       ],
       env: {
-        MODULES: "julia/0.5.1#{" cuda/8.0.44" if cuda}"
+        MODULES: "julia/0.5.1 #{cuda}"
       }
     },
     julia064: {
-      display_name: "Julia 0.6.4 [julia/0.6.4#{" cuda/8.0.44" if cuda}]",
+      display_name: "Julia 0.6.4 [julia/0.6.4 #{cuda}]",
       language: "julia",
       argv: [
         wrapper,
@@ -95,11 +95,11 @@
         "{connection_file}"
       ],
       env: {
-        MODULES: "julia/0.6.4#{" cuda/8.0.44" if cuda}"
+        MODULES: "julia/0.6.4 #{cuda}"
       }
     },
     julia100: {
-      display_name: "Julia 1.0.0 [julia/1.0.0#{" cuda/8.0.44" if cuda}]",
+      display_name: "Julia 1.0.0 [julia/1.0.0 #{cuda}]",
       language: "julia",
       argv: [
         wrapper,
@@ -111,7 +111,7 @@
         "{connection_file}"
       ],
       env: {
-        MODULES: "julia/1.0.0#{" cuda/8.0.44" if cuda}"
+        MODULES: "julia/1.0.0 #{cuda}"
       }
     },
   }

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
 <%-
-  p context.version
   cuda = (context.node_type == "gpu") ? context.cuda_version : ""
   wrapper = session.staged_root.join("launch_wrapper.sh")
   wrapper_log = session.staged_root.join("launch_wrapper.log")

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 <%-
+  p context.version
   cuda = (context.node_type == "gpu") ? context.cuda_version : ""
   wrapper = session.staged_root.join("launch_wrapper.sh")
   wrapper_log = session.staged_root.join("launch_wrapper.log")


### PR DESCRIPTION
This adds a CUDA version select that is shown/used only when the `node_type` is a GPU. This PR also adds core clamping based on `node_type` with the hardware config for the JavaScript config pulled from data attributes specified in `form.yml`.