### PR TITLE
Conditionally add IJulia 1.x kernel only if the user has it installed for themselves

### DIFF
--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -2,6 +2,81 @@
 
 <%-
   require 'pathname'
+
+  # @returns [[major_minor_version, "lmod_load_string"], ["0.6", "julia/0.6.4"]]
+  def get_lmod_julia_versions
+      `ssh -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no owens.osc.edu 'bash --login -c "module spider julia"' 2>&1`.scan(
+          /julia\/(?:(?<maj>\d+)\.(?<min>\d+)\.(?<pat>\d+))/
+      ).uniq.map do |mtch|
+          [
+              "#{mtch[0]}.#{mtch[1]}",
+              "#{mtch.join('.')}"
+          ]
+      end
+  end
+
+  # @returns [[major_minor_version, kernel_version], ["1.0", "1.20.0"]]
+  def get_active_user_ijulia_kernel_versions
+      user_julia_envs = Pathname.new("~/.julia/environments/").expand_path
+
+      if ! user_julia_envs.exist?
+          []
+      else
+          user_julia_envs.children.select do |child|
+              child.directory? && child.to_s.match?(/v\d+\.\d+/) && child.join('Manifest.toml').exist?
+          end.map do |child|
+              [
+                  child.basename.to_s.gsub('v', ''),
+                  child.join('Manifest.toml').read.match(/\[\[IJulia\]\].+?version\s*=\s*"(?<version>\d+\.\d+\.\d+)"\n/m)
+              ]
+          end.select do |pair|
+              pair[-1]
+          end.map do |pair|
+              pair[-1] = pair[-1][:version]
+              pair
+          end
+      end
+  end
+
+  # @returns [[kernel_version, path_to_kernel], ["1.19.0", #<Pathname:/users/PZS0710/zyou/.julia/packages/IJulia/cwvsj/src/kernel.jl>]]
+  def get_installed_user_ijulia_kernels
+      ijulia_installation_root = Pathname.new("~/.julia/packages/IJulia").expand_path
+
+      if ! ijulia_installation_root.exist?
+          []
+      else
+          ijulia_installation_root.children.select do |child|
+              child.join('Project.toml').exist?
+          end.map do |child|
+              [
+                  child.join('Project.toml').read.match(/version\s*=\s*"(?<version>\d+\.\d+\.\d+)"/)[:version],
+                  child.join('src/kernel.jl')
+              ]
+          end
+      end
+  end
+
+  def kernel_hash(
+      cuda:, installation:, lmod_version:, wrapper:
+  )
+      {
+        display_name: "User Defined Julia #{lmod_version}" + ((cuda.empty?) ? "" : " [#{cuda}]"),
+        language: "julia",
+        argv: [
+          wrapper,
+          "julia",
+          "-i",
+          "--startup-file=yes",
+          "--color=yes",
+          installation.join("src/kernel.jl").to_s,
+          "{connection_file}"
+        ],
+        env: {
+          MODULES: "xalt/latest julia/#{lmod_version} #{cuda}"
+        }
+      }
+  end
+
   cuda = (context.node_type == "gpu") ? context.cuda_version : ""
   wrapper = session.staged_root.join("launch_wrapper.sh")
   wrapper_log = session.staged_root.join("launch_wrapper.log")
@@ -98,6 +173,7 @@
       env: {
         MODULES: "xalt/latest julia/0.6.4 #{cuda}"
       },
+    },
     julia100: {
       display_name: "Julia 1.0.0 [julia/1.0.0 #{cuda}]",
       language: "julia",
@@ -114,43 +190,23 @@
         MODULES: "xalt/latest julia/1.0.0 #{cuda}"
       }
     },
-  }
-    }
   }.tap do |hsh|
-    # Due to problems using a mix of user and site modules the site module for IJulia 1.x will be removed
-    # This detect if a user has IJulia installed for themselves and if so will provide a kernel
-    manifest = Pathname.new("~/.julia/environments/v1.1/Manifest.toml").expand_path
-    ijulia_installation_root = Pathname.new("~/.julia/packages/IJulia").expand_path
+    # Any existing Julia kernelspec may be clobbered if the user has their own version of that kernel installed
+    lmod_julia_versions = Hash[get_lmod_julia_versions]
+    installed_user_ijulia_kernels = Hash[get_installed_user_ijulia_kernels]
 
-    if manifest.exist? and ijulia_installation_root.exist?
-        if matches = manifest.read.match(/\[\[IJulia\]\].+?version\s*=\s*"(?<version>\d+\.\d+\.\d+)"\n/m)
-            active_ijulia_version = matches[:version]
+    get_active_user_ijulia_kernel_versions.each do |maj_min_ver, kernel_version|
+        lmod_version = lmod_julia_versions[maj_min_ver]
 
-            ijulia_installation_root.children.select do |installation|
-                begin
-                    installation.join('Project.toml').read.match(/version\s*=\s*"(?<version>\d+\.\d+\.\d+)"/)[:version] == active_ijulia_version
-                rescue StandardError => e
-                    return false
-                end
-            end.each do |installation|
-                hsh[:julia100] = {
-                  display_name: "User Defined Julia #{active_ijulia_version}" + ((cuda.empty?) ? "" : " [#{cuda}]"),
-                  language: "julia",
-                  argv: [
-                    wrapper,
-                    "julia",
-                    "-i",
-                    "--startup-file=yes",
-                    "--color=yes",
-                    installation.join("src/kernel.jl").to_s,
-                    "{connection_file}"
-                  ],
-                  env: {
-                    MODULES: "xalt/latest #{cuda}"
-                  }
-                }
-            end
-        end
+        next unless lmod_version
+        next unless installed_user_ijulia_kernels[kernel_version]
+
+        hsh["julia#{lmod_version.gsub('.', '')}".to_sym] = kernel_hash(
+            cuda: cuda,
+            installation: installed_user_ijulia_kernels[kernel_version],
+            lmod_version: lmod_version,
+            wrapper: wrapper
+        )
     end
   end
 -%>

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -17,7 +17,7 @@
 
   # @returns [[major_minor_version, kernel_version], ["1.0", "1.20.0"]]
   def get_active_user_ijulia_kernel_versions
-      user_julia_envs = Pathname.new("~zyou/.julia/environments/").expand_path
+      user_julia_envs = Pathname.new("~/.julia/environments/").expand_path
 
       if ! user_julia_envs.exist?
           []
@@ -40,7 +40,7 @@
 
   # @returns [[kernel_version, path_to_kernel], ["1.19.0", #<Pathname:/users/PZS0710/zyou/.julia/packages/IJulia/cwvsj/src/kernel.jl>]]
   def get_installed_user_ijulia_kernels
-      ijulia_installation_root = Pathname.new("~zyou/.julia/packages/IJulia").expand_path
+      ijulia_installation_root = Pathname.new("~/.julia/packages/IJulia").expand_path
 
       if ! ijulia_installation_root.exist?
           []

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -97,7 +97,24 @@
       ],
       env: {
         MODULES: "xalt/latest julia/0.6.4 #{cuda}"
+      },
+    julia100: {
+      display_name: "Julia 1.0.0 [julia/1.0.0 #{cuda}]",
+      language: "julia",
+      argv: [
+        wrapper,
+        "julia",
+        "-i",
+        "--startup-file=yes",
+        "--color=yes",
+        "/usr/local/julia/1.0.0/site/packages/IJulia/fRegO/src/kernel.jl",
+        "{connection_file}"
+      ],
+      env: {
+        MODULES: "xalt/latest julia/1.0.0 #{cuda}"
       }
+    },
+  }
     }
   }.tap do |hsh|
     # Due to problems using a mix of user and site modules the site module for IJulia 1.x will be removed
@@ -116,8 +133,8 @@
                     return false
                 end
             end.each do |installation|
-                hsh["julia#{active_ijulia_version.gsub('.', '').to_sym}"] = {
-                  display_name: "Julia #{active_ijulia_version}" + ((cuda.empty?) ? "" : " [#{cuda}]"),
+                hsh[:julia100] = {
+                  display_name: "User Defined Julia #{active_ijulia_version}" + ((cuda.empty?) ? "" : " [#{cuda}]"),
                   language: "julia",
                   argv: [
                     wrapper,

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -17,7 +17,7 @@
 
   # @returns [[major_minor_version, kernel_version], ["1.0", "1.20.0"]]
   def get_active_user_ijulia_kernel_versions
-      user_julia_envs = Pathname.new("~/.julia/environments/").expand_path
+      user_julia_envs = Pathname.new("~zyou/.julia/environments/").expand_path
 
       if ! user_julia_envs.exist?
           []
@@ -40,7 +40,7 @@
 
   # @returns [[kernel_version, path_to_kernel], ["1.19.0", #<Pathname:/users/PZS0710/zyou/.julia/packages/IJulia/cwvsj/src/kernel.jl>]]
   def get_installed_user_ijulia_kernels
-      ijulia_installation_root = Pathname.new("~/.julia/packages/IJulia").expand_path
+      ijulia_installation_root = Pathname.new("~zyou/.julia/packages/IJulia").expand_path
 
       if ! ijulia_installation_root.exist?
           []
@@ -50,7 +50,7 @@
           end.map do |child|
               [
                   child.join('Project.toml').read.match(/version\s*=\s*"(?<version>\d+\.\d+\.\d+)"/)[:version],
-                  child.join('src/kernel.jl')
+                  child.join('src/kernel.jl').to_s
               ]
           end
       end
@@ -68,7 +68,7 @@
           "-i",
           "--startup-file=yes",
           "--color=yes",
-          installation.join("src/kernel.jl").to_s,
+          installation,
           "{connection_file}"
         ],
         env: {

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 <%-
+  require 'pathname'
   cuda = (context.node_type == "gpu") ? context.cuda_version : ""
   wrapper = session.staged_root.join("launch_wrapper.sh")
   wrapper_log = session.staged_root.join("launch_wrapper.log")
@@ -97,24 +98,44 @@
       env: {
         MODULES: "xalt/latest julia/0.6.4 #{cuda}"
       }
-    },
-    julia100: {
-      display_name: "Julia 1.0.0 [julia/1.0.0 #{cuda}]",
-      language: "julia",
-      argv: [
-        wrapper,
-        "julia",
-        "-i",
-        "--startup-file=yes",
-        "--color=yes",
-        "/usr/local/julia/1.0.0/site/packages/IJulia/fRegO/src/kernel.jl",
-        "{connection_file}"
-      ],
-      env: {
-        MODULES: "xalt/latest julia/1.0.0 #{cuda}"
-      }
-    },
-  }
+    }
+  }.tap do |hsh|
+    # Due to problems using a mix of user and site modules the site module for IJulia 1.x will be removed
+    # This detect if a user has IJulia installed for themselves and if so will provide a kernel
+    manifest = Pathname.new("~/.julia/environments/v1.1/Manifest.toml").expand_path
+    ijulia_installation_root = Pathname.new("~/.julia/packages/IJulia").expand_path
+
+    if manifest.exist? and ijulia_installation_root.exist?
+        if matches = manifest.read.match(/\[\[IJulia\]\].+?version\s*=\s*"(?<version>\d+\.\d+\.\d+)"\n/m)
+            active_ijulia_version = matches[:version]
+
+            ijulia_installation_root.children.select do |installation|
+                begin
+                    installation.join('Project.toml').read.match(/version\s*=\s*"(?<version>\d+\.\d+\.\d+)"/)[:version] == active_ijulia_version
+                rescue StandardError => e
+                    return false
+                end
+            end.each do |installation|
+                hsh["julia#{active_ijulia_version.gsub('.', '').to_sym}"] = {
+                  display_name: "Julia #{active_ijulia_version}" + ((cuda.empty?) ? "" : " [#{cuda}]"),
+                  language: "julia",
+                  argv: [
+                    wrapper,
+                    "julia",
+                    "-i",
+                    "--startup-file=yes",
+                    "--color=yes",
+                    installation.join("src/kernel.jl").to_s,
+                    "{connection_file}"
+                  ],
+                  env: {
+                    MODULES: "xalt/latest #{cuda}"
+                  }
+                }
+            end
+        end
+    end
+  end
 -%>
 
 echo "Starting main script..."


### PR DESCRIPTION
Fixes issue described in Incident INC0345013.

```
I found the current setup is not working if a user has installed packages in home directory.

$ module load julia/1.0.0
$ julia
julia> import IJulia
[ Info: Precompiling IJulia [7073ff75-c697-5162-941a-fcdaad2a7d2a]
(v1.0) pkg> add Optim
[ .. skipped .. ]
julia> import IJulia
ERROR: ArgumentError: Package IJulia not found in current path:
- Run `Pkg.add("IJulia")` to install the IJulia package.

This is because Julia uses registries from the global project ($OSC_JULIA_DIR/site/environments/v1.0/Project.toml) while the home project (~/.julia/environments/v1.0/Project.toml) is empty. I don't find any way to combine both projects.

I think the best way is to let users manage their own IJulia kernel. In bc_osc_jupyter, we can point to $HOME/.julia/packages/IJulia/<version_tag>/src/kernel.jl. The question is how to let users to chose the version tag? 
```