### PR TITLE
Simplify cuda toggle

### DIFF
--- a/form.js
+++ b/form.js
@@ -49,7 +49,7 @@ function set_ppn_by_node_type(node_type_input, num_cores_input) {
  * @param      {string}    form_id  The form identifier
  * @param      {boolean}   show     Whether to show or hide
  */
-function toggle_visibilty_of_form_group(form_id, show) {
+function toggle_visibility_of_form_group(form_id, show) {
   let form_element = $(form_id);
   let parent = form_element.parent();
 
@@ -74,7 +74,7 @@ function toggle_cuda_version_visibility() {
     return;
   }
 
-  toggle_visibilty_of_form_group(
+  toggle_visibility_of_form_group(
     '#batch_connect_session_context_cuda_version',
     node_type_input.find(':selected').data('can-show-cuda')
   );
@@ -85,13 +85,13 @@ function toggle_cuda_version_visibility() {
  */
 function set_node_type_change_handler() {
   let node_type_input = $('#batch_connect_session_context_node_type');
-  node_type_input.change(node_type_change_hander);
+  node_type_input.change(node_type_change_handler);
 }
 
 /**
  * Update UI when node_type changes
  */
-function node_type_change_hander() {
+function node_type_change_handler() {
   fix_num_cores();
   toggle_cuda_version_visibility();
 }

--- a/form.js
+++ b/form.js
@@ -44,7 +44,7 @@ function set_ppn_by_node_type(node_type_input, num_cores_input) {
 }
 
 /**
- * Toggle the visibilty of a form group
+ * Toggle the visibility of a form group
  *
  * @param      {string}    form_id  The form identifier
  * @param      {boolean}   show     Whether to show or hide
@@ -52,6 +52,11 @@ function set_ppn_by_node_type(node_type_input, num_cores_input) {
 function toggle_visibility_of_form_group(form_id, show) {
   let form_element = $(form_id);
   let parent = form_element.parent();
+
+  // kick out if you didn't find what you're looking for
+  if(parent.size() <= 0) {
+    return;
+  }
 
   if(show) {
     parent.show();
@@ -62,22 +67,12 @@ function toggle_visibility_of_form_group(form_id, show) {
 }
 
 /**
- * Toggle the visibilty of the CUDA select
- *
- * Looking for the value of data-can-show-cuda
+ * Toggle the visibility of the CUDA select when the selected
+ * node_type changes
  */
-function toggle_cuda_version_visibility() {
-  let node_type_input = $('#batch_connect_session_context_node_type');
-
-  // Allow for cuda_version control not existing
-  if ( ! ($('#batch_connect_session_context_cuda_version').length > 0) ) {
-    return;
-  }
-
-  toggle_visibility_of_form_group(
-    '#batch_connect_session_context_cuda_version',
-    node_type_input.find(':selected').data('can-show-cuda')
-  );
+function toggle_cuda_version_visibility(selected_node_type) {
+  const cuda_element = $('#batch_connect_session_context_cuda_version');
+  toggle_visibility_of_form_group(cuda_element, selected_node_type == 'gpu');
 }
 
 /**
@@ -85,15 +80,15 @@ function toggle_cuda_version_visibility() {
  */
 function set_node_type_change_handler() {
   let node_type_input = $('#batch_connect_session_context_node_type');
-  node_type_input.change(node_type_change_handler);
+  node_type_input.change((event) => node_type_change_handler(event));
 }
 
 /**
  * Update UI when node_type changes
  */
-function node_type_change_handler() {
+function node_type_change_handler(event) {
   fix_num_cores();
-  toggle_cuda_version_visibility();
+  toggle_cuda_version_visibility(event.target.value);
 }
 
 /**
@@ -102,7 +97,9 @@ function node_type_change_handler() {
 
 // Set controls to align with the values of the last session context
 fix_num_cores();
-toggle_cuda_version_visibility();
+toggle_cuda_version_visibility(
+  $('#batch_connect_session_context_node_type option:selected').val()
+);
 
 // Install event handlers
 set_node_type_change_handler();

--- a/form.yml
+++ b/form.yml
@@ -63,26 +63,22 @@ attributes:
       - [
           "any",     "any",
           data-min-ppn: 0,
-          data-max-ppn: 28,
-          data-can-show-cuda: false
+          data-max-ppn: 28
         ]
       - [
           "gpu",     "gpu",
           data-min-ppn: 0,
-          data-max-ppn: 28,
-          data-can-show-cuda: true
+          data-max-ppn: 28
         ]
       - [
           "hugemem", "hugemem",
           data-min-ppn: 48,
-          data-max-ppn: 48,
-          data-can-show-cuda: false
+          data-max-ppn: 48
         ]
       - [
           "debug",   "debug",
           data-min-ppn: 0,
-          data-max-ppn: 28,
-          data-can-show-cuda: false
+          data-max-ppn: 28
         ]
   version:
     widget: "select"


### PR DESCRIPTION
Looking into #39 I saw there's at least this one modification we can make beforehand to simplify all the data attributes to limit complexity.

This PR doesn't change current behaviour and is just a refactor to use the javascript `event` instead of determining what's currently selected.