### PR TITLE
Class updates

### DIFF
--- a/template/before.sh.erb
+++ b/template/before.sh.erb
@@ -45,7 +45,6 @@ module load <%= context.version %>
 #
 # Note we make the directory even if there's nothing to copy
 mkdir -p "$HOME/osc_classes/$OSC_CLASS_ID"
-JUPYTER_API="tree/osc_classes/$OSC_CLASS_ID"
 NOTEBOOK_ROOT="$HOME/osc_classes/$OSC_CLASS_ID"
 
 if [[ -n "$OSC_CLASS_FILES" ]]; then

--- a/template/before.sh.erb
+++ b/template/before.sh.erb
@@ -9,30 +9,9 @@ SALT="$(create_passwd 16)"
 password="$(create_passwd 16)"
 PASSWORD_SHA1="$(echo -n "${password}${SALT}" | openssl dgst -sha1 | awk '{print $NF}')"
 
-# Notebook root directory
-export NOTEBOOK_ROOT="${NOTEBOOK_ROOT:-${HOME}}"
-
 # The `$CONFIG_FILE` environment variable is exported as it is used in the main
 # `script.sh.erb` file when launching the Jupyter server.
 export CONFIG_FILE="${PWD}/config.py"
-
-# Generate Jupyter configuration file with secure file permissions
-(
-umask 077
-cat > "${CONFIG_FILE}" << EOL
-c.JupyterApp.config_file_name = 'ondemand_config'
-c.KernelSpecManager.ensure_native_kernel = False
-c.NotebookApp.ip = '*'
-c.NotebookApp.port = ${port}
-c.NotebookApp.port_retries = 0
-c.NotebookApp.password = u'sha1:${SALT}:${PASSWORD_SHA1}'
-c.NotebookApp.base_url = '/node/${host}/${port}/'
-c.NotebookApp.open_browser = False
-c.NotebookApp.allow_origin = '*'
-c.NotebookApp.notebook_dir = '${NOTEBOOK_ROOT}'
-c.NotebookApp.disable_check_xsrf = True
-EOL
-)
 
 # Safari users hit this error https://github.com/jupyterlab/jupyterlab/issues/5486
 # so let's make a new workspace dir that's this job's PWD and copy the defult /lab
@@ -67,6 +46,7 @@ module load <%= context.version %>
 # Note we make the directory even if there's nothing to copy
 mkdir -p "$HOME/osc_classes/$OSC_CLASS_ID"
 JUPYTER_API="tree/osc_classes/$OSC_CLASS_ID"
+NOTEBOOK_ROOT="$HOME/osc_classes/$OSC_CLASS_ID"
 
 if [[ -n "$OSC_CLASS_FILES" ]]; then
   # Copy over classroom materials
@@ -80,3 +60,24 @@ module purge
 
 export JUPYTERLAB_WORKSPACES_DIR=$PWD
 export jupyter_api="$JUPYTER_API"
+
+# Notebook root directory
+export NOTEBOOK_ROOT="${NOTEBOOK_ROOT:-${HOME}}"
+
+# Generate Jupyter configuration file with secure file permissions
+(
+umask 077
+cat > "${CONFIG_FILE}" << EOL
+c.JupyterApp.config_file_name = 'ondemand_config'
+c.KernelSpecManager.ensure_native_kernel = False
+c.NotebookApp.ip = '*'
+c.NotebookApp.port = ${port}
+c.NotebookApp.port_retries = 0
+c.NotebookApp.password = u'sha1:${SALT}:${PASSWORD_SHA1}'
+c.NotebookApp.base_url = '/node/${host}/${port}/'
+c.NotebookApp.open_browser = False
+c.NotebookApp.allow_origin = '*'
+c.NotebookApp.notebook_dir = '${NOTEBOOK_ROOT}'
+c.NotebookApp.disable_check_xsrf = True
+EOL
+)

--- a/template/before.sh.erb
+++ b/template/before.sh.erb
@@ -45,6 +45,7 @@ module load <%= context.version %>
 #
 # Note we make the directory even if there's nothing to copy
 mkdir -p "$HOME/osc_classes/$OSC_CLASS_ID"
+touch "$HOME/osc_classes/$OSC_CLASS_ID/0_${OSC_CLASS_ID:-osc_class}.md"
 NOTEBOOK_ROOT="$HOME/osc_classes/$OSC_CLASS_ID"
 
 if [[ -n "$OSC_CLASS_FILES" ]]; then

--- a/template/before.sh.erb
+++ b/template/before.sh.erb
@@ -64,13 +64,15 @@ module load <%= context.version %>
 # OSC_CLASS_FILES is the instructor's project directory we need to copy from.
 # OSC_CLASS_ID is the name of the class (eg. BIOCHEM5721).
 #
+# Note we make the directory even if there's nothing to copy
+mkdir -p "$HOME/osc_classes/$OSC_CLASS_ID"
+JUPYTER_API="tree/osc_classes/$OSC_CLASS_ID"
+
 if [[ -n "$OSC_CLASS_FILES" ]]; then
   # Copy over classroom materials
   set -x
   rsync -avz --ignore-existing "$OSC_CLASS_FILES" "$HOME/osc_classes/$OSC_CLASS_ID"
   { set +x; } 2>/dev/null
-
-  JUPYTER_API="tree/osc_classes/$OSC_CLASS_ID"
 fi
 
 module purge

--- a/template/before.sh.erb
+++ b/template/before.sh.erb
@@ -68,7 +68,6 @@ export NOTEBOOK_ROOT="${NOTEBOOK_ROOT:-${HOME}}"
 (
 umask 077
 cat > "${CONFIG_FILE}" << EOL
-c.JupyterApp.config_file_name = 'ondemand_config'
 c.KernelSpecManager.ensure_native_kernel = False
 c.NotebookApp.ip = '*'
 c.NotebookApp.port = ${port}


### PR DESCRIPTION
I obviously can't test this yet but it seems simple enough. In either case, I won't merge until I can.

This:
- sets the NOTEBOOK_ROOT for classrooms
- removes 'c.JupyterApp.config_file_name = 'ondemand_config'' configuration because it seems pointless and it conflicts with nbgrader
- makes and redirects to "$HOME/osc_classes/$OSC_CLASS_ID" even if there's nothing to copy