### PR TITLE
merge pitzer-exp into pitzer

### DIFF
--- a/form.js
+++ b/form.js
@@ -159,23 +159,6 @@ function toggle_options(element_name) {
 }
 
 /**
- * If the user submits a blank value for num_cores, fill in the maximum 
- * value for that cluster & node-type combination
- */
-function submit_blank_cores() {
-  let node_type_input = $('#batch_connect_session_context_node_type');
-  let num_cores_input = $('#batch_connect_session_context_num_cores');
-
-  if(num_cores_input.val() !== '') {
-    return;
-  } else {
-    const data = node_type_input.find(':selected').data();
-    const max = data["maxPpn" + current_cluster_capitalized()];
-    num_cores_input.val(max);
-  }
-}
-
-/**
  * Find the max cores for the cluster given node type
  * that's currently selected
  *
@@ -259,8 +242,3 @@ toggle_options("batch_connect_session_context_node_type");
 // Install event handlers
 set_node_type_change_handler();
 set_cluster_change_handler();
-
-// when users launch, set num_cores if it's a blank value
-$(document).on("submit", function() {
-  submit_blank_cores();
-});

--- a/form.yml
+++ b/form.yml
@@ -152,8 +152,8 @@ attributes:
         ]
       - [
           "largemem", "largemem",
-          data-min-ppn-owens: 48,
-          data-max-ppn-owens: 48,
+          data-min-ppn-pitzer: 48,
+          data-max-ppn-pitzer: 48,
           data-option-for-owens: false,
           data-option-for-pitzer: true
         ]

--- a/form.yml
+++ b/form.yml
@@ -16,7 +16,6 @@ attributes:
     options:
       - "owens"
       - "pitzer"
-      - "pitzer-exp"
   jupyterlab_switch:
     widget: "check_box"
     label: "Use JupyterLab instead of Jupyter Notebook?"
@@ -45,95 +44,118 @@ attributes:
       - [ 
           "cuda/8.0.44",    "cuda/8.0.44",
           data-option-for-owens: true,
-          data-option-for-pitzer: false,
-          data-option-for-pitzer-exp: false
+          data-option-for-pitzer: false
         ]
       - [ 
           "cuda/8.0.61",    "cuda/8.0.61",
           data-option-for-owens: true,
-          data-option-for-pitzer: false,
-          data-option-for-pitzer-exp: false
+          data-option-for-pitzer: false
         ]
       - [ 
           "cuda/9.0.176",   "cuda/9.0.176",
           data-option-for-owens: true,
-          data-option-for-pitzer: true,
-          data-option-for-pitzer-exp: true
+          data-option-for-pitzer: true
         ]
       - [ 
           "cuda/9.1.85",    "cuda/9.1.85",
           data-option-for-owens: true,
-          data-option-for-pitzer: true,
-          data-option-for-pitzer-exp: true
+          data-option-for-pitzer: true
         ]
       - [ 
           "cuda/9.2.88",    "cuda/9.2.88",
           data-option-for-owens: true,
-          data-option-for-pitzer: true,
-          data-option-for-pitzer-exp: true
+          data-option-for-pitzer: true
         ]
       - [ 
           "cuda/10.0.130",  "cuda/10.0.130",
           data-option-for-owens: true,
-          data-option-for-pitzer: true,
-          data-option-for-pitzer-exp: true
+          data-option-for-pitzer: true
         ]
       - [ 
           "cuda/10.1.168",  "cuda/10.1.168",
           data-option-for-owens: true,
-          data-option-for-pitzer: true,
-          data-option-for-pitzer-exp: true
+          data-option-for-pitzer: true
         ]
       - [
           "cuda/10.2.89",   "cuda/10.2.89",
           data-option-for-owens: true,
-          data-option-for-pitzer: true,
-          data-option-for-pitzer-exp: true
+          data-option-for-pitzer: true
         ]
   node_type:
     widget: select
     label: "Node type"
     help: |
-      Owens nodes have up to 28 cores available and Pitzer nodes have up to 40.
-
-      - **any** - Use any available node. This reduces the wait time as there are no node requirements.
-      - **gpu** - Use a node that has a GPU and loads the requested [CUDA] module.
-        - Owens has 160 of these nodes with a [NVIDIA Tesla P100 GPU].
-        - Pitzer has 32 of these nodes with two [NVIDIA Tensor Core V100 GPU]s.
-      - **hugemem** - Use a node that has a large amounts of RAM cores.
-        - Owens has 16 of these nodes with 1.5TB of RAM and 40 cores.
-        - Pitzer has 4 of these nodes with 3TB of RAM and 80 cores.
-      - **debug** - For short sessions (= 1 hour) the debug queue
-        will have the shortest wait time. This is only accessible during 8AM -
-        6PM, Monday - Friday. There are 6 of these nodes on both Owens and Pitzer.
+      - **Standard Compute** <br>
+        These are standard HPC machines. Owens has 648 of these nodes with 40
+        cores and 128 GB of memory. Pitzer has 224 with 40 cores and
+        340 with 48. All pitzer nodes have 192 GB of RAM. Chosing any will decrease
+        your wait time.
+      - **GPU Enabled** <br>
+        These are HPC machines GPUs. Owens has 160 nodes with 1 [NVIDIA Tesla P100 GPU]
+        on Owens and Pitzer has 74 with 2 [NVIDIA Tesla V100 GPUs]. They have the same
+        CPU and memory characteristics of standard compute. Though Pitzer's 40 core machines
+        have 2 GPUs with 16 GB of RAM and 48 core machines have 2with 32 GB of RAM.
+        Densegpu types have 4 GPUs with 16 GB of RAM.
+      - **Large Memory** <br>
+        These are HPC machines with very large amounts of memory. Owens has 16 hugemem
+        with 48 cores and 1.5 TB of RAM. Pitzer has 4 with 3 TB of RAM and 80 cores.
+        Pitzer also has 12 Largmem nodes have 48 cores with 768 GB of RAM.
 
       [NVIDIA Tesla P100 GPU]: http://www.nvidia.com/object/tesla-p100.html
-      [NVIDIA Tensor Core V100 GPU]: https://www.nvidia.com/en-us/data-center/v100/
-      [CUDA]: https://developer.nvidia.com/cuda-zone
+      [NVIDIA Tesla V100 GPUs]: https://www.nvidia.com/en-us/data-center/v100/
     options:
       - [
           "any",     "any",
           data-min-ppn-owens: 1,
           data-max-ppn-owens: 28,
           data-min-ppn-pitzer: 1,
-          data-max-ppn-pitzer: 40,
-          data-min-ppn-pitzer-exp: 1,
-          data-max-ppn-pitzer-exp: 48,
+          data-max-ppn-pitzer: 48,
           data-option-for-owens: true,
-          data-option-for-pitzer: true,
-          data-option-for-pitzer-exp: true
+          data-option-for-pitzer: true
         ]
       - [
-          "gpu",     "gpu",
+          "40 core",     "any-40core",
+          data-min-ppn-pitzer: 1,
+          data-max-ppn-pitzer: 40,
+          data-option-for-owens: false,
+          data-option-for-pitzer: true
+        ]
+      - [
+          "48 core",     "any-48core",
+          data-min-ppn-pitzer: 1,
+          data-max-ppn-pitzer: 48,
+          data-option-for-owens: false,
+          data-option-for-pitzer: true
+        ]
+      - [
+          "any gpu",     "gpu",
           data-min-ppn-owens: 1,
           data-max-ppn-owens: 28,
           data-min-ppn-pitzer: 1,
-          data-max-ppn-pitzer: 40,
-          data-min-ppn-pitzer-exp: 1,
-          data-max-ppn-pitzer-exp: 48,
+          data-max-ppn-pitzer: 48,
           data-option-for-owens: true,
-          data-option-for-pitzer: true,
-          data-option-for-pitzer-exp: true
+          data-option-for-pitzer: true
+        ]
+      - [
+          "40 core gpu",     "gpu-40core",
+          data-min-ppn-pitzer: 1,
+          data-max-ppn-pitzer: 40,
+          data-option-for-owens: false,
+          data-option-for-pitzer: true
+        ]
+      - [
+          "48 core gpu",     "gpu-48core",
+          data-min-ppn-pitzer: 1,
+          data-max-ppn-pitzer: 48,
+          data-option-for-owens: false,
+          data-option-for-pitzer: true
+        ]
+      - [
+          "largemem", "largemem",
+          data-min-ppn-owens: 48,
+          data-max-ppn-owens: 48,
+          data-option-for-owens: false,
+          data-option-for-pitzer: true
         ]
       - [
           "hugemem", "hugemem",
@@ -142,20 +164,16 @@ attributes:
           data-min-ppn-pitzer: 80,
           data-max-ppn-pitzer: 80,
           data-option-for-owens: true,
-          data-option-for-pitzer: true,
-          data-option-for-pitzer-exp: false
+          data-option-for-pitzer: true
         ]
       - [
           "debug",   "debug",
           data-min-ppn-owens: 1,
           data-max-ppn-owens: 28,
           data-min-ppn-pitzer: 1,
-          data-max-ppn-pitzer: 40,
-          data-min-ppn-pitzer-exp: 1,
-          data-max-ppn-pitzer-exp: 48,
+          data-max-ppn-pitzer: 48,
           data-option-for-owens: true,
-          data-option-for-pitzer: true,
-          data-option-for-pitzer-exp: true
+          data-option-for-pitzer: true
         ]
   version:
     widget: "select"

--- a/submit.yml.erb
+++ b/submit.yml.erb
@@ -1,21 +1,47 @@
 <%-
-  ppn             = num_cores.to_i
-  base_slurm_args = ["--nodes", "1", "--ntasks-per-node", "#{ppn}"]
+  cores = num_cores.to_i
+
+  if cores == 0 && cluster == "pitzer"
+    # little optimization for pitzer nodes. They want the whole node, if they chose 'any',
+    # it can be scheduled on p18 or p20 nodes. If not, they'll get the constraint below.
+    base_slurm_args = ["--nodes", "1", "--exclusive"]
+  elsif cores == 0
+    # full node on owens
+    cores = 28
+    base_slurm_args = ["--nodes", "1", "--ntasks-per-node", "28"]
+  else
+    base_slurm_args = ["--nodes", "1", "--ntasks-per-node", "#{cores}"]
+  end
 
   slurm_args = case node_type
               when "gpu"
                 base_slurm_args += ["--gpus-per-node", "1"]
+              when "gpu-40core"
+                base_slurm_args += ["--gpus-per-node", "1", "--constraint", "40core"]
+              when "gpu-48core"
+                base_slurm_args += ["--gpus-per-node", "1", "--constraint", "48core"]
+              when "any-40core"
+                base_slurm_args += ["--constraint", "40core"]
+              when "any-48core"
+                base_slurm_args += ["--constraint", "48core"]
+              when "hugemem"
+                base_slurm_args += ["--partition", "hugemem", "--exclusive"]
+              when "largemem"
+                base_slurm_args += ["--partition", "largemem", "--exclusive"]
+              when "debug"
+                # partition handled in the script.queue_name below. Need to change when Owens switches to Slurm
+                base_slurm_args += ["--exclusive"]
               else
                 base_slurm_args
               end
 
   torque_args = case node_type
               when "gpu"
-                ":ppn=#{ppn}:gpus=1"
+                ":ppn=#{cores}:gpus=1"
               when "hugemem"
-                ppn == 80 ? ":ppn=#{ppn},mem=2989GB" : ":ppn=#{ppn}"
+                ppn == 80 ? ":ppn=#{cores},mem=2989GB" : ":ppn=#{cores}"
               else
-                ":ppn=#{ppn}"
+                ":ppn=#{cores}"
               end
 
 -%>
@@ -29,7 +55,7 @@ script:
   queue_name: "debug"
   <%- end -%>
   native:
-    <%- unless cluster == 'pitzer-exp' %>
+    <%- if cluster == 'owens' %>
     resources:
       nodes: "1<%= torque_args %>"
     <%- else %>


### PR DESCRIPTION
- change help language to show all owens and pitzer complexities
- change the way blank input for cores is handled.
  Instead of handling black cores in the javascript, we can again
  handle this in the submit.yml.erb more easily as there are fewer
  options and --exclusive let's us not care about max cores available.