### PR TITLE
change form target when user agent appears to be ipad from Zoom

### DIFF
--- a/view.html.erb
+++ b/view.html.erb
@@ -5,9 +5,19 @@
   next_url  = "#{base_url}/#{jupyter_api}"
 
   full_url="#{login_url}?next=#{URI.encode(next_url)}"
+  form_id = "juypyter_form#{login_url.gsub('/', '_')}"
 %>
 
-<form action="<%= full_url %>" method="post" target="_blank">
+<script type="text/javascript">
+  function changeTarget() {
+    var agent = navigator.userAgent;
+    if (/Macintosh/.test(agent)) {
+      document.getElementById("<%= form_id %>").target = "_self";
+    }
+  }
+</script>
+
+<form id="<%= form_id %>" action="<%= full_url %>" method="post" target="_blank" onsubmit="changeTarget()" >
   <input type="hidden" name="password" value="<%= password %>">
   <button class="btn btn-primary" type="submit">
     <i class="fa fa-cogs"></i> Connect to Jupyter

--- a/view.html.erb
+++ b/view.html.erb
@@ -1,4 +1,3 @@
-
 <%-
   base_url  = "/node/#{host}/#{port}"
   login_url = "#{base_url}/login"
@@ -8,10 +7,11 @@
   form_id = "juypyter_form#{login_url.gsub('/', '_')}"
 %>
 
+<!-- Zoom on iPad doesn't like opening in a new tab. It won't foward the form parameters. -->
 <script type="text/javascript">
   function changeTarget() {
-    var agent = navigator.userAgent;
-    if (/Macintosh/.test(agent)) {
+    const agent = navigator.userAgent;
+    if (/Mozilla\/5.0 \(Macintosh; Intel Mac OS X \d+_\d+_\d+\) AppleWebKit\/\d+.\d+.\d+ \(KHTML, like Gecko\)/.test(agent)) {
       document.getElementById("<%= form_id %>").target = "_self";
     }
   }

--- a/view.html.erb
+++ b/view.html.erb
@@ -11,7 +11,7 @@
 <script type="text/javascript">
   function changeTarget() {
     const agent = navigator.userAgent;
-    if (/Mozilla\/5.0 \(Macintosh; Intel Mac OS X \d+_\d+_\d+\) AppleWebKit\/\d+.\d+.\d+ \(KHTML, like Gecko\)/.test(agent)) {
+    if (/Mozilla\/5\.0 \(Macintosh; Intel Mac OS X \d+_\d+_\d+\) AppleWebKit\/\d+\.\d+\.\d+ \(KHTML, like Gecko\)/.test(agent)) {
       document.getElementById("<%= form_id %>").target = "_self";
     }
   }


### PR DESCRIPTION
When using Zoom on the iPad and sharing content through a URL, the built-in browser doesn't see to work well with new tabs.  It opens the new tab, but doesn't forward the hidden parameter for password, so Jupyter prompts the user for it.

The full user agent is: `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/605.1.15 (KHTML, like Gecko)`
Which seems to be different enough from Chrome on the ipad which is `Mozilla/5.0 (iPad; CPU OS 13_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/85.0.4183.109 Mobile/15E148 Safari/604.1`