### PR TITLE
rm unused owens-slurm data attributes

### DIFF
--- a/form.yml.erb
+++ b/form.yml.erb
@@ -50,49 +50,41 @@ attributes:
       - [ 
           "cuda/8.0.44",    "cuda/8.0.44",
           data-option-for-owens: true,
-          data-option-for-owens-slurm: true,
           data-option-for-pitzer: false
         ]
       - [ 
           "cuda/8.0.61",    "cuda/8.0.61",
           data-option-for-owens: true,
-          data-option-for-owens-slurm: true,
           data-option-for-pitzer: false
         ]
       - [ 
           "cuda/9.0.176",   "cuda/9.0.176",
           data-option-for-owens: true,
-          data-option-for-owens-slurm: true,
           data-option-for-pitzer: true
         ]
       - [ 
           "cuda/9.1.85",    "cuda/9.1.85",
           data-option-for-owens: true,
-          data-option-for-owens-slurm: true,
           data-option-for-pitzer: true
         ]
       - [ 
           "cuda/9.2.88",    "cuda/9.2.88",
           data-option-for-owens: true,
-          data-option-for-owens-slurm: true,
           data-option-for-pitzer: true
         ]
       - [ 
           "cuda/10.0.130",  "cuda/10.0.130",
           data-option-for-owens: true,
-          data-option-for-owens-slurm: true,
           data-option-for-pitzer: true
         ]
       - [ 
           "cuda/10.1.168",  "cuda/10.1.168",
           data-option-for-owens: true,
-          data-option-for-owens-slurm: true,
           data-option-for-pitzer: true
         ]
       - [
           "cuda/10.2.89",   "cuda/10.2.89",
           data-option-for-owens: true,
-          data-option-for-owens-slurm: true,
           data-option-for-pitzer: true
         ]
   node_type:
@@ -122,12 +114,9 @@ attributes:
           "any",     "any",
           data-min-ppn-owens: 1,
           data-max-ppn-owens: 28,
-          data-min-ppn-owens-slurm: 1,
-          data-max-ppn-owens-slurm: 28,
           data-min-ppn-pitzer: 1,
           data-max-ppn-pitzer: 48,
           data-option-for-owens: true,
-          data-option-for-owens-slurm: true,
           data-option-for-pitzer: true
         ]
       - [
@@ -135,7 +124,6 @@ attributes:
           data-min-ppn-pitzer: 1,
           data-max-ppn-pitzer: 40,
           data-option-for-owens: false,
-          data-option-for-owens-slurm: false,
           data-option-for-pitzer: true
         ]
       - [
@@ -143,19 +131,15 @@ attributes:
           data-min-ppn-pitzer: 1,
           data-max-ppn-pitzer: 48,
           data-option-for-owens: false,
-          data-option-for-owens-slurm: false,
           data-option-for-pitzer: true
         ]
       - [
           "any gpu",     "gpu",
           data-min-ppn-owens: 1,
           data-max-ppn-owens: 28,
-          data-min-ppn-owens-slurm: 1,
-          data-max-ppn-owens-slurm: 28,
           data-min-ppn-pitzer: 1,
           data-max-ppn-pitzer: 48,
           data-option-for-owens: true,
-          data-option-for-owens-slurm: true,
           data-option-for-pitzer: true
         ]
       - [
@@ -163,7 +147,6 @@ attributes:
           data-min-ppn-pitzer: 1,
           data-max-ppn-pitzer: 40,
           data-option-for-owens: false,
-          data-option-for-owens-slurm: false,
           data-option-for-pitzer: true
         ]
       - [
@@ -171,7 +154,6 @@ attributes:
           data-min-ppn-pitzer: 1,
           data-max-ppn-pitzer: 48,
           data-option-for-owens: false,
-          data-option-for-owens-slurm: false,
           data-option-for-pitzer: true
         ]
       - [
@@ -179,31 +161,24 @@ attributes:
           data-min-ppn-pitzer: 48,
           data-max-ppn-pitzer: 48,
           data-option-for-owens: false,
-          data-option-for-owens-slurm: false,
           data-option-for-pitzer: true
         ]
       - [
           "hugemem", "hugemem",
           data-min-ppn-owens: 48,
           data-max-ppn-owens: 48,
-          data-min-ppn-owens-slurm: 48,
-          data-max-ppn-owens-slurm: 48,
           data-min-ppn-pitzer: 80,
           data-max-ppn-pitzer: 80,
           data-option-for-owens: true,
-          data-option-for-owens-slurm: true,
           data-option-for-pitzer: true
         ]
       - [
           "debug",   "debug",
           data-min-ppn-owens: 1,
           data-max-ppn-owens: 28,
-          data-min-ppn-owens-slurm: 1,
-          data-max-ppn-owens-slurm: 28,
           data-min-ppn-pitzer: 1,
           data-max-ppn-pitzer: 48,
           data-option-for-owens: true,
-          data-option-for-owens-slurm: true,
           data-option-for-pitzer: true
         ]
   version:


### PR DESCRIPTION
rm unused owens-slurm data attributes that were missed when I removed the actual owen-slurm functionality.