### PR TITLE
Support Kubernetes

### DIFF
--- a/form.js
+++ b/form.js
@@ -216,6 +216,16 @@ function toggle_cuda_version_visibility(selected_node_type) {
 }
 
 /**
+ * Toggle the visibility of the email on started field
+ */
+function toggle_email_on_started(selected_cluster) {
+  const element = $('#batch_connect_session_context_bc_email_on_started');
+  const supported = selected_cluster != 'kubernetes';;
+
+  toggle_visibility_of_form_group(element, supported);
+}
+
+/**
  * Sets the change handler for the node_type select.
  */
 function set_node_type_change_handler() {
@@ -246,6 +256,7 @@ function cluster_change_handler(event) {
   fix_num_cores(event);
   toggle_options("batch_connect_session_context_node_type");
   toggle_cuda_version_visibility(event.target.value);
+  toggle_email_on_started(event.target.value);
 }
 
 /**
@@ -256,6 +267,9 @@ function cluster_change_handler(event) {
 fix_num_cores({ target: document.querySelector('#batch_connect_session_node_type') });
 toggle_cuda_version_visibility(
   $('#batch_connect_session_context_node_type option:selected').val()
+);
+toggle_email_on_started(
+  $('#batch_connect_session_context_cluster option:selected').val()
 );
 toggle_options("batch_connect_session_context_cuda_version");
 toggle_options("batch_connect_session_context_node_type");

--- a/form.js
+++ b/form.js
@@ -186,7 +186,7 @@ function max_cores_for_cluster(cluster_name) {
  */
 function toggle_cuda_version_visibility(selected_node_type) {
   const cuda_element = $('#batch_connect_session_context_cuda_version');
-  const choose_gpu = selected_node_type == 'gpu';
+  const choose_gpu = selected_node_type.includes('gpu');
 
   toggle_visibility_of_form_group(cuda_element, choose_gpu);
   if(choose_gpu){

--- a/form.js
+++ b/form.js
@@ -199,7 +199,7 @@ function toggle_cuda_version_visibility(selected_node_type) {
  */
 function toggle_email_on_started(selected_cluster) {
   const element = $('#batch_connect_session_context_bc_email_on_started');
-  const supported = selected_cluster != 'kubernetes';;
+  const supported = !selected_cluster.includes('kubernetes');
 
   toggle_visibility_of_form_group(element, supported);
 }

--- a/form.js
+++ b/form.js
@@ -21,23 +21,6 @@ function current_cluster_capitalized(){
 }
 
 /**
- * Simple helper to return the selected node type.
- */
-function current_node_type(){
-  var node_type = $('#batch_connect_session_context_node_type').val();
-  return node_type;
-}
-
-/**
-  * Helper to return capitalized cluster name from node type
-  */
-function current_cluster_node_type(){
-  var node_type = current_node_type();
-  var cluster_node_type = capitalize_words(node_type.split("-")[0]);
-  return cluster_node_type;
-}
-
-/**
  * Capitalize the words in a string and remove and '-'.  In the simplest case
  * it simple capitalizes.  It assumes 'words' are hyphenated.
  *
@@ -146,7 +129,6 @@ function toggle_visibility_of_form_group(form_id, show) {
  */
 function toggle_options(element_name) {
   const cluster = current_cluster_capitalized();
-  const cluster_node_type = current_cluster_node_type();
   const search = "#" + element_name + " option"
   const options = $(search);
 
@@ -155,10 +137,7 @@ function toggle_options(element_name) {
     // or hide methods so we have to query for it again
     let option_element = $(search + "[value='" + option.value + "']");
     let data = option_element.data();
-    let show = data["optionFor" + cluster + cluster_node_type];
-    if (typeof show === 'undefined') {
-      show = data["optionFor" + cluster];
-    }
+    let show = data["optionFor" + cluster];
 
     if(show) {
       option_element.show();
@@ -254,8 +233,8 @@ function node_type_change_handler(event) {
  */
 function cluster_change_handler(event) {
   fix_num_cores(event);
+  toggle_options("batch_connect_session_context_cuda_version");
   toggle_options("batch_connect_session_context_node_type");
-  toggle_cuda_version_visibility(event.target.value);
   toggle_email_on_started(event.target.value);
 }
 

--- a/form.js
+++ b/form.js
@@ -232,9 +232,9 @@ function node_type_change_handler(event) {
  * Update UI when the cluster changes
  */
 function cluster_change_handler(event) {
-  fix_num_cores(event);
   toggle_options("batch_connect_session_context_cuda_version");
   toggle_options("batch_connect_session_context_node_type");
+  fix_num_cores(event);
   toggle_email_on_started(event.target.value);
 }
 

--- a/form.js
+++ b/form.js
@@ -21,6 +21,23 @@ function current_cluster_capitalized(){
 }
 
 /**
+ * Simple helper to return the selected node type.
+ */
+function current_node_type(){
+  var node_type = $('#batch_connect_session_context_node_type').val();
+  return node_type;
+}
+
+/**
+  * Helper to return capitalized cluster name from node type
+  */
+function current_cluster_node_type(){
+  var node_type = current_node_type();
+  var cluster_node_type = capitalize_words(node_type.split("-")[0]);
+  return cluster_node_type;
+}
+
+/**
  * Capitalize the words in a string and remove and '-'.  In the simplest case
  * it simple capitalizes.  It assumes 'words' are hyphenated.
  *
@@ -129,6 +146,7 @@ function toggle_visibility_of_form_group(form_id, show) {
  */
 function toggle_options(element_name) {
   const cluster = current_cluster_capitalized();
+  const cluster_node_type = current_cluster_node_type();
   const search = "#" + element_name + " option"
   const options = $(search);
 
@@ -137,7 +155,10 @@ function toggle_options(element_name) {
     // or hide methods so we have to query for it again
     let option_element = $(search + "[value='" + option.value + "']");
     let data = option_element.data();
-    let show = data["optionFor" + cluster];
+    let show = data["optionFor" + cluster + cluster_node_type];
+    if (typeof show === 'undefined') {
+      show = data["optionFor" + cluster];
+    }
 
     if(show) {
       option_element.show();
@@ -223,8 +244,8 @@ function node_type_change_handler(event) {
  */
 function cluster_change_handler(event) {
   fix_num_cores(event);
-  toggle_options("batch_connect_session_context_cuda_version");
   toggle_options("batch_connect_session_context_node_type");
+  toggle_cuda_version_visibility(event.target.value);
 }
 
 /**

--- a/form.yml.erb
+++ b/form.yml.erb
@@ -8,6 +8,8 @@ cluster:
   - "owens"
   - "pitzer"
   - "kubernetes"
+  - "kubernetes-test"
+  - "kubernetes-dev"
 form:
   - account
   - jupyterlab_switch

--- a/form.yml.erb
+++ b/form.yml.erb
@@ -54,49 +54,57 @@ attributes:
           "cuda/8.0.44",    "cuda/8.0.44",
           data-option-for-owens: true,
           data-option-for-pitzer: false,
-          data-option-for-kubernetes: false
+          data-option-for-kubernetes-owens: true,
+          data-option-for-kubernetes-pitzer: false
         ]
       - [ 
           "cuda/8.0.61",    "cuda/8.0.61",
           data-option-for-owens: true,
           data-option-for-pitzer: false,
-          data-option-for-kubernetes: false
+          data-option-for-kubernetes-owens: true,
+          data-option-for-kubernetes-pitzer: false
         ]
       - [ 
           "cuda/9.0.176",   "cuda/9.0.176",
           data-option-for-owens: true,
           data-option-for-pitzer: true,
-          data-option-for-kubernetes: true
+          data-option-for-kubernetes-owens: true,
+          data-option-for-kubernetes-pitzer: true
         ]
       - [ 
           "cuda/9.1.85",    "cuda/9.1.85",
           data-option-for-owens: true,
           data-option-for-pitzer: true,
-          data-option-for-kubernetes: true
+          data-option-for-kubernetes-owens: true,
+          data-option-for-kubernetes-pitzer: true
         ]
       - [ 
           "cuda/9.2.88",    "cuda/9.2.88",
           data-option-for-owens: true,
           data-option-for-pitzer: true,
-          data-option-for-kubernetes: true
+          data-option-for-kubernetes-owens: true,
+          data-option-for-kubernetes-pitzer: true
         ]
       - [ 
           "cuda/10.0.130",  "cuda/10.0.130",
           data-option-for-owens: true,
           data-option-for-pitzer: true,
-          data-option-for-kubernetes: true
+          data-option-for-kubernetes-owens: true,
+          data-option-for-kubernetes-pitzer: true
         ]
       - [ 
           "cuda/10.1.168",  "cuda/10.1.168",
           data-option-for-owens: true,
           data-option-for-pitzer: true,
-          data-option-for-kubernetes: true
+          data-option-for-kubernetes-owens: true,
+          data-option-for-kubernetes-pitzer: true
         ]
       - [
           "cuda/10.2.89",   "cuda/10.2.89",
           data-option-for-owens: true,
           data-option-for-pitzer: true,
-          data-option-for-kubernetes: true
+          data-option-for-kubernetes-owens: true,
+          data-option-for-kubernetes-pitzer: true
         ]
   node_type:
     widget: select

--- a/form.yml.erb
+++ b/form.yml.erb
@@ -52,57 +52,49 @@ attributes:
           "cuda/8.0.44",    "cuda/8.0.44",
           data-option-for-owens: true,
           data-option-for-pitzer: false,
-          data-option-for-kubernetes-owens: true,
-          data-option-for-kubernetes-pitzer: false
+          data-option-for-kubernetes: false
         ]
       - [ 
           "cuda/8.0.61",    "cuda/8.0.61",
           data-option-for-owens: true,
           data-option-for-pitzer: false,
-          data-option-for-kubernetes-owens: true,
-          data-option-for-kubernetes-pitzer: false
+          data-option-for-kubernetes: false
         ]
       - [ 
           "cuda/9.0.176",   "cuda/9.0.176",
           data-option-for-owens: true,
           data-option-for-pitzer: true,
-          data-option-for-kubernetes-owens: true,
-          data-option-for-kubernetes-pitzer: true
+          data-option-for-kubernetes: true
         ]
       - [ 
           "cuda/9.1.85",    "cuda/9.1.85",
           data-option-for-owens: true,
           data-option-for-pitzer: true,
-          data-option-for-kubernetes-owens: true,
-          data-option-for-kubernetes-pitzer: true
+          data-option-for-kubernetes: true
         ]
       - [ 
           "cuda/9.2.88",    "cuda/9.2.88",
           data-option-for-owens: true,
           data-option-for-pitzer: true,
-          data-option-for-kubernetes-owens: true,
-          data-option-for-kubernetes-pitzer: true
+          data-option-for-kubernetes: true
         ]
       - [ 
           "cuda/10.0.130",  "cuda/10.0.130",
           data-option-for-owens: true,
           data-option-for-pitzer: true,
-          data-option-for-kubernetes-owens: true,
-          data-option-for-kubernetes-pitzer: true
+          data-option-for-kubernetes: true
         ]
       - [ 
           "cuda/10.1.168",  "cuda/10.1.168",
           data-option-for-owens: true,
           data-option-for-pitzer: true,
-          data-option-for-kubernetes-owens: true,
-          data-option-for-kubernetes-pitzer: true
+          data-option-for-kubernetes: true,
         ]
       - [
           "cuda/10.2.89",   "cuda/10.2.89",
           data-option-for-owens: true,
           data-option-for-pitzer: true,
-          data-option-for-kubernetes-owens: true,
-          data-option-for-kubernetes-pitzer: true
+          data-option-for-kubernetes: true
         ]
   node_type:
     widget: select

--- a/form.yml.erb
+++ b/form.yml.erb
@@ -54,49 +54,65 @@ attributes:
           "cuda/8.0.44",    "cuda/8.0.44",
           data-option-for-owens: true,
           data-option-for-pitzer: false,
-          data-option-for-kubernetes: false
+          data-option-for-kubernetes: false,
+          data-option-for-kubernetes-test: false,
+          data-option-for-kubernetes-dev: false  
         ]
       - [ 
           "cuda/8.0.61",    "cuda/8.0.61",
           data-option-for-owens: true,
           data-option-for-pitzer: false,
-          data-option-for-kubernetes: false
+          data-option-for-kubernetes: false,
+          data-option-for-kubernetes-test: false,
+          data-option-for-kubernetes-dev: false
         ]
       - [ 
           "cuda/9.0.176",   "cuda/9.0.176",
           data-option-for-owens: true,
           data-option-for-pitzer: true,
-          data-option-for-kubernetes: true
+          data-option-for-kubernetes: true,
+          data-option-for-kubernetes-test: true,
+          data-option-for-kubernetes-dev: true
         ]
       - [ 
           "cuda/9.1.85",    "cuda/9.1.85",
           data-option-for-owens: true,
           data-option-for-pitzer: true,
-          data-option-for-kubernetes: true
+          data-option-for-kubernetes: true,
+          data-option-for-kubernetes-test: true,
+          data-option-for-kubernetes-dev: true
         ]
       - [ 
           "cuda/9.2.88",    "cuda/9.2.88",
           data-option-for-owens: true,
           data-option-for-pitzer: true,
-          data-option-for-kubernetes: true
+          data-option-for-kubernetes: true,
+          data-option-for-kubernetes-test: true,
+          data-option-for-kubernetes-dev: true
         ]
       - [ 
           "cuda/10.0.130",  "cuda/10.0.130",
           data-option-for-owens: true,
           data-option-for-pitzer: true,
-          data-option-for-kubernetes: true
+          data-option-for-kubernetes: true,
+          data-option-for-kubernetes-test: true,
+          data-option-for-kubernetes-dev: true
         ]
       - [ 
           "cuda/10.1.168",  "cuda/10.1.168",
           data-option-for-owens: true,
           data-option-for-pitzer: true,
           data-option-for-kubernetes: true,
+          data-option-for-kubernetes-test: true,
+          data-option-for-kubernetes-dev: true
         ]
       - [
           "cuda/10.2.89",   "cuda/10.2.89",
           data-option-for-owens: true,
           data-option-for-pitzer: true,
-          data-option-for-kubernetes: true
+          data-option-for-kubernetes: true,
+          data-option-for-kubernetes-test: true,
+          data-option-for-kubernetes-dev: true
         ]
   node_type:
     widget: select
@@ -129,7 +145,9 @@ attributes:
           data-max-ppn-pitzer: 48,
           data-option-for-owens: true,
           data-option-for-pitzer: true,
-          data-option-for-kubernetes: false
+          data-option-for-kubernetes: false,
+          data-option-for-kubernetes-test: false,
+          data-option-for-kubernetes-dev: false
         ]
       - [
           "40 core",     "any-40core",
@@ -137,7 +155,9 @@ attributes:
           data-max-ppn-pitzer: 40,
           data-option-for-owens: false,
           data-option-for-pitzer: true,
-          data-option-for-kubernetes: false
+          data-option-for-kubernetes: false,
+          data-option-for-kubernetes-test: false,
+          data-option-for-kubernetes-dev: false
         ]
       - [
           "48 core",     "any-48core",
@@ -145,7 +165,9 @@ attributes:
           data-max-ppn-pitzer: 48,
           data-option-for-owens: false,
           data-option-for-pitzer: true,
-          data-option-for-kubernetes: false
+          data-option-for-kubernetes: false,
+          data-option-for-kubernetes-test: false,
+          data-option-for-kubernetes-dev: false
         ]
       - [
           "any gpu",     "gpu",
@@ -155,7 +177,9 @@ attributes:
           data-max-ppn-pitzer: 48,
           data-option-for-owens: true,
           data-option-for-pitzer: true,
-          data-option-for-kubernetes: false
+          data-option-for-kubernetes: false,
+          data-option-for-kubernetes-test: false,
+          data-option-for-kubernetes-dev: false
         ]
       - [
           "40 core gpu",     "gpu-40core",
@@ -163,7 +187,9 @@ attributes:
           data-max-ppn-pitzer: 40,
           data-option-for-owens: false,
           data-option-for-pitzer: true,
-          data-option-for-kubernetes: false
+          data-option-for-kubernetes: false,
+          data-option-for-kubernetes-test: false,
+          data-option-for-kubernetes-dev: false
         ]
       - [
           "48 core gpu",     "gpu-48core",
@@ -171,7 +197,9 @@ attributes:
           data-max-ppn-pitzer: 48,
           data-option-for-owens: false,
           data-option-for-pitzer: true,
-          data-option-for-kubernetes: false
+          data-option-for-kubernetes: false,
+          data-option-for-kubernetes-test: false,
+          data-option-for-kubernetes-dev: false
         ]
       - [
           "largemem", "largemem",
@@ -179,7 +207,9 @@ attributes:
           data-max-ppn-pitzer: 48,
           data-option-for-owens: false,
           data-option-for-pitzer: true,
-          data-option-for-kubernetes: false
+          data-option-for-kubernetes: false,
+          data-option-for-kubernetes-test: false,
+          data-option-for-kubernetes-dev: false
         ]
       - [
           "hugemem", "hugemem",
@@ -189,7 +219,9 @@ attributes:
           data-max-ppn-pitzer: 80,
           data-option-for-owens: true,
           data-option-for-pitzer: true,
-          data-option-for-kubernetes: false
+          data-option-for-kubernetes: false,
+          data-option-for-kubernetes-test: false,
+          data-option-for-kubernetes-dev: false
         ]
       - [
           "debug",   "debug",
@@ -199,31 +231,41 @@ attributes:
           data-max-ppn-pitzer: 48,
           data-option-for-owens: true,
           data-option-for-pitzer: true,
-          data-option-for-kubernetes: false
+          data-option-for-kubernetes: false,
+          data-option-for-kubernetes-test: false,
+          data-option-for-kubernetes-dev: false
         ]
       - [
           "pitzer",   "pitzer",
           data-option-for-owens: false,
           data-option-for-pitzer: false,
-          data-option-for-kubernetes: true
+          data-option-for-kubernetes: true,
+          data-option-for-kubernetes-test: true,
+          data-option-for-kubernetes-dev: true
         ]
       - [
           "owens",   "owens",
           data-option-for-owens: false,
           data-option-for-pitzer: false,
-          data-option-for-kubernetes: true
+          data-option-for-kubernetes: true,
+          data-option-for-kubernetes-test: true,
+          data-option-for-kubernetes-dev: true
         ]
       - [
           "pitzer gpu",   "pitzer-gpu",
           data-option-for-owens: false,
           data-option-for-pitzer: false,
-          data-option-for-kubernetes: true
+          data-option-for-kubernetes: true,
+          data-option-for-kubernetes-test: true,
+          data-option-for-kubernetes-dev: true
         ]
       - [
           "owens gpu",   "owens-gpu",
           data-option-for-owens: false,
           data-option-for-pitzer: false,
-          data-option-for-kubernetes: true
+          data-option-for-kubernetes: true,
+          data-option-for-kubernetes-test: true,
+          data-option-for-kubernetes-dev: true
         ]
   version:
     widget: "select"

--- a/form.yml.erb
+++ b/form.yml.erb
@@ -208,7 +208,7 @@ attributes:
           data-option-for-kubernetes: true
         ]
       - [
-          "pitzer",   "owens",
+          "owens",   "owens",
           data-option-for-owens: false,
           data-option-for-pitzer: false,
           data-option-for-kubernetes: true

--- a/form.yml.erb
+++ b/form.yml.erb
@@ -7,6 +7,9 @@
 cluster:
   - "owens"
   - "pitzer"
+<% if OodAppkit.clusters["kubernetes"].allow? -%>
+  - "kubernetes"
+<% end -%>
 form:
   - account
   - jupyterlab_switch
@@ -50,42 +53,50 @@ attributes:
       - [ 
           "cuda/8.0.44",    "cuda/8.0.44",
           data-option-for-owens: true,
-          data-option-for-pitzer: false
+          data-option-for-pitzer: false,
+          data-option-for-kubernetes: false
         ]
       - [ 
           "cuda/8.0.61",    "cuda/8.0.61",
           data-option-for-owens: true,
-          data-option-for-pitzer: false
+          data-option-for-pitzer: false,
+          data-option-for-kubernetes: false
         ]
       - [ 
           "cuda/9.0.176",   "cuda/9.0.176",
           data-option-for-owens: true,
-          data-option-for-pitzer: true
+          data-option-for-pitzer: true,
+          data-option-for-kubernetes: true
         ]
       - [ 
           "cuda/9.1.85",    "cuda/9.1.85",
           data-option-for-owens: true,
-          data-option-for-pitzer: true
+          data-option-for-pitzer: true,
+          data-option-for-kubernetes: true
         ]
       - [ 
           "cuda/9.2.88",    "cuda/9.2.88",
           data-option-for-owens: true,
-          data-option-for-pitzer: true
+          data-option-for-pitzer: true,
+          data-option-for-kubernetes: true
         ]
       - [ 
           "cuda/10.0.130",  "cuda/10.0.130",
           data-option-for-owens: true,
-          data-option-for-pitzer: true
+          data-option-for-pitzer: true,
+          data-option-for-kubernetes: true
         ]
       - [ 
           "cuda/10.1.168",  "cuda/10.1.168",
           data-option-for-owens: true,
-          data-option-for-pitzer: true
+          data-option-for-pitzer: true,
+          data-option-for-kubernetes: true
         ]
       - [
           "cuda/10.2.89",   "cuda/10.2.89",
           data-option-for-owens: true,
-          data-option-for-pitzer: true
+          data-option-for-pitzer: true,
+          data-option-for-kubernetes: true
         ]
   node_type:
     widget: select
@@ -117,21 +128,24 @@ attributes:
           data-min-ppn-pitzer: 1,
           data-max-ppn-pitzer: 48,
           data-option-for-owens: true,
-          data-option-for-pitzer: true
+          data-option-for-pitzer: true,
+          data-option-for-kubernetes: false
         ]
       - [
           "40 core",     "any-40core",
           data-min-ppn-pitzer: 1,
           data-max-ppn-pitzer: 40,
           data-option-for-owens: false,
-          data-option-for-pitzer: true
+          data-option-for-pitzer: true,
+          data-option-for-kubernetes: false
         ]
       - [
           "48 core",     "any-48core",
           data-min-ppn-pitzer: 1,
           data-max-ppn-pitzer: 48,
           data-option-for-owens: false,
-          data-option-for-pitzer: true
+          data-option-for-pitzer: true,
+          data-option-for-kubernetes: false
         ]
       - [
           "any gpu",     "gpu",
@@ -140,28 +154,32 @@ attributes:
           data-min-ppn-pitzer: 1,
           data-max-ppn-pitzer: 48,
           data-option-for-owens: true,
-          data-option-for-pitzer: true
+          data-option-for-pitzer: true,
+          data-option-for-kubernetes: false
         ]
       - [
           "40 core gpu",     "gpu-40core",
           data-min-ppn-pitzer: 1,
           data-max-ppn-pitzer: 40,
           data-option-for-owens: false,
-          data-option-for-pitzer: true
+          data-option-for-pitzer: true,
+          data-option-for-kubernetes: false
         ]
       - [
           "48 core gpu",     "gpu-48core",
           data-min-ppn-pitzer: 1,
           data-max-ppn-pitzer: 48,
           data-option-for-owens: false,
-          data-option-for-pitzer: true
+          data-option-for-pitzer: true,
+          data-option-for-kubernetes: false
         ]
       - [
           "largemem", "largemem",
           data-min-ppn-pitzer: 48,
           data-max-ppn-pitzer: 48,
           data-option-for-owens: false,
-          data-option-for-pitzer: true
+          data-option-for-pitzer: true,
+          data-option-for-kubernetes: false
         ]
       - [
           "hugemem", "hugemem",
@@ -170,7 +188,8 @@ attributes:
           data-min-ppn-pitzer: 80,
           data-max-ppn-pitzer: 80,
           data-option-for-owens: true,
-          data-option-for-pitzer: true
+          data-option-for-pitzer: true,
+          data-option-for-kubernetes: false
         ]
       - [
           "debug",   "debug",
@@ -179,7 +198,32 @@ attributes:
           data-min-ppn-pitzer: 1,
           data-max-ppn-pitzer: 48,
           data-option-for-owens: true,
-          data-option-for-pitzer: true
+          data-option-for-pitzer: true,
+          data-option-for-kubernetes: false
+        ]
+      - [
+          "pitzer",   "pitzer",
+          data-option-for-owens: false,
+          data-option-for-pitzer: false,
+          data-option-for-kubernetes: true
+        ]
+      - [
+          "pitzer",   "owens",
+          data-option-for-owens: false,
+          data-option-for-pitzer: false,
+          data-option-for-kubernetes: true
+        ]
+      - [
+          "pitzer gpu",   "pitzer-gpu",
+          data-option-for-owens: false,
+          data-option-for-pitzer: false,
+          data-option-for-kubernetes: true
+        ]
+      - [
+          "owens gpu",   "owens-gpu",
+          data-option-for-owens: false,
+          data-option-for-pitzer: false,
+          data-option-for-kubernetes: true
         ]
   version:
     widget: "select"

--- a/form.yml.erb
+++ b/form.yml.erb
@@ -7,7 +7,7 @@
 cluster:
   - "owens"
   - "pitzer"
-<% if OodAppkit.clusters["kubernetes"].allow? -%>
+<% if !OodAppkit.clusters["kubernetes"].nil? && OodAppkit.clusters["kubernetes"].allow? -%>
   - "kubernetes"
 <% end -%>
 form:

--- a/form.yml.erb
+++ b/form.yml.erb
@@ -7,9 +7,7 @@
 cluster:
   - "owens"
   - "pitzer"
-<% if !OodAppkit.clusters["kubernetes"].nil? && OodAppkit.clusters["kubernetes"].allow? -%>
   - "kubernetes"
-<% end -%>
 form:
   - account
   - jupyterlab_switch

--- a/form.yml.erb
+++ b/form.yml.erb
@@ -237,6 +237,12 @@ attributes:
         ]
       - [
           "pitzer",   "pitzer",
+          data-min-ppn-kubernetes: 1,
+          data-max-ppn-kubernetes: 10,
+          data-min-ppn-kubernetes-test: 1,
+          data-max-ppn-kubernetes-test: 10,
+          data-min-ppn-kubernetes-dev: 1,
+          data-max-ppn-kubernetes-dev: 6,
           data-option-for-owens: false,
           data-option-for-pitzer: false,
           data-option-for-kubernetes: true,
@@ -245,6 +251,12 @@ attributes:
         ]
       - [
           "owens",   "owens",
+          data-min-ppn-kubernetes: 1,
+          data-max-ppn-kubernetes: 10,
+          data-min-ppn-kubernetes-test: 1,
+          data-max-ppn-kubernetes-test: 10,
+          data-min-ppn-kubernetes-dev: 1,
+          data-max-ppn-kubernetes-dev: 6,
           data-option-for-owens: false,
           data-option-for-pitzer: false,
           data-option-for-kubernetes: true,
@@ -253,6 +265,12 @@ attributes:
         ]
       - [
           "pitzer gpu",   "pitzer-gpu",
+          data-min-ppn-kubernetes: 1,
+          data-max-ppn-kubernetes: 10,
+          data-min-ppn-kubernetes-test: 1,
+          data-max-ppn-kubernetes-test: 10,
+          data-min-ppn-kubernetes-dev: 1,
+          data-max-ppn-kubernetes-dev: 6,
           data-option-for-owens: false,
           data-option-for-pitzer: false,
           data-option-for-kubernetes: true,
@@ -261,6 +279,12 @@ attributes:
         ]
       - [
           "owens gpu",   "owens-gpu",
+          data-min-ppn-kubernetes: 1,
+          data-max-ppn-kubernetes: 10,
+          data-min-ppn-kubernetes-test: 1,
+          data-max-ppn-kubernetes-test: 10,
+          data-min-ppn-kubernetes-dev: 1,
+          data-max-ppn-kubernetes-dev: 6,
           data-option-for-owens: false,
           data-option-for-pitzer: false,
           data-option-for-kubernetes: true,

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,5 +1,5 @@
 ---
-name: Jupyter (Owens and Pitzer)
+name: Jupyter
 category: Interactive Apps
 subcategory: Servers
 role: batch_connect

--- a/submit.yml.erb
+++ b/submit.yml.erb
@@ -47,7 +47,7 @@ script:
     <%- slurm_args.each do |arg| %>
     - "<%= arg %>"
     <%- end %>
-<% elsif cluster == 'kubernetes'
+<% elsif cluster =~ /kubernetes/
    if node_type =~ /owens/
      compute_cluster = "owens"
      apps_path = "/usr/local"

--- a/submit.yml.erb
+++ b/submit.yml.erb
@@ -57,6 +57,7 @@ script:
    end
    mounts = {
      'home'    => OodSupport::User.new.home,
+     'support' => OodSupport::User.new('support').home,
      'project' => '/fs/project',
      'scratch' => '/fs/scratch',
      'ess'     => '/fs/ess',

--- a/submit.yml.erb
+++ b/submit.yml.erb
@@ -134,5 +134,5 @@ script:
         path: /apps/<%= compute_cluster %>
         destination_path: <%= apps_path %>
     node_selector:
-      cluster: <%= compute_cluster %>
+      osc.edu/cluster: <%= compute_cluster %>
 <% end -%>

--- a/submit.yml.erb
+++ b/submit.yml.erb
@@ -73,7 +73,7 @@ script:
   native:
     container:
       name: "jupyter"
-      image: "docker-registry.osc.edu/ondemand/ondemand-base-rhel7:0.1.0"
+      image: "docker-registry.osc.edu/ondemand/ondemand-base-rhel7:0.2.0"
       image_pull_policy: "IfNotPresent"
       command: ["/bin/bash","-l","<%= staged_root %>/job_script_content.sh"]
       restart_policy: 'OnFailure'

--- a/submit.yml.erb
+++ b/submit.yml.erb
@@ -55,6 +55,12 @@ script:
      compute_cluster = "pitzer"
      apps_path = "/apps"
    end
+   mounts = {
+     'home'    => OodSupport::User.new.home,
+     'project' => '/fs/project',
+     'scratch' => '/fs/scratch',
+     'ess'     => '/fs/ess',
+   }
 -%>
 ---
 script:
@@ -80,11 +86,13 @@ script:
       cpu: "<%= num_cores %>"
       memory: "<%= num_cores.to_i * 4 %>Gi"
     mounts:
+    <%- mounts.each_pair do |name, mount| -%>
       - type: host
-        name: home
+        name: <%= name %>
         host_type: Directory
-        path: <%= OodSupport::User.new.home %>
-        destination_path: <%= OodSupport::User.new.home %>
+        path: <%= mount %>
+        destination_path: <%= mount %>
+    <%- end -%>
       - type: host
         name: munge-socket
         host_type: Socket

--- a/submit.yml.erb
+++ b/submit.yml.erb
@@ -72,8 +72,8 @@ script:
   native:
     container:
       name: "jupyter"
-      image: "docker-registry.osc.edu/ondemand/ondemand-base-rhel7:0.0.3"
-      image_pull_policy: "Always"
+      image: "docker-registry.osc.edu/ondemand/ondemand-base-rhel7:0.1.0"
+      image_pull_policy: "IfNotPresent"
       command: ["/bin/bash","-l","<%= staged_root %>/job_script_content.sh"]
       restart_policy: 'OnFailure'
       env:

--- a/submit.yml.erb
+++ b/submit.yml.erb
@@ -35,6 +35,7 @@
               end
 
 -%>
+<% if cluster =~ /owens|pitzer/ -%>
 ---
 batch_connect:
   template: "basic"
@@ -46,3 +47,84 @@ script:
     <%- slurm_args.each do |arg| %>
     - "<%= arg %>"
     <%- end %>
+<% elsif cluster == 'kubernetes'
+   if node_type =~ /owens/
+     compute_cluster = "owens"
+     apps_path = "/usr/local"
+   elsif node_type =~ /pitzer/
+     compute_cluster = "pitzer"
+     apps_path = "/apps"
+   end
+-%>
+---
+script:
+  accounting_id: "<%= account %>"
+  wall_time: "<%= bc_num_hours.to_i * 3600 %>"
+  <%- if node_type =~ /gpu/ -%>
+  gpus_per_node: 1
+  <%- end -%>
+  native:
+    container:
+      name: "jupyter"
+      image: "docker-registry.osc.edu/ondemand/ondemand-base-rhel7:0.0.3"
+      image_pull_policy: "Always"
+      command: ["/bin/bash","-l","<%= staged_root %>/job_script_content.sh"]
+      restart_policy: 'OnFailure'
+      env:
+        NB_UID: "<%= Etc.getpwnam(ENV['USER']).uid %>"
+        NB_USER: "<%= ENV['USER'] %>"
+        NB_GID: "<%= Etc.getpwnam(ENV['USER']).gid %>"
+        CLUSTER: "<%= compute_cluster %>"
+        KUBECONFIG: "/dev/null"
+      port: "8080"
+      cpu: "<%= num_cores %>"
+      memory: "<%= num_cores.to_i * 4 %>Gi"
+    mounts:
+      - type: host
+        name: home
+        host_type: Directory
+        path: <%= OodSupport::User.new.home %>
+        destination_path: <%= OodSupport::User.new.home %>
+      - type: host
+        name: munge-socket
+        host_type: Socket
+        path: /var/run/munge/munge.socket.2
+        destination_path: /var/run/munge/munge.socket.2
+      - type: host
+        name: slurm-conf
+        host_type: Directory
+        path: /etc/slurm
+        destination_path: /etc/slurm
+      - type: host
+        name: sssd-pipes
+        host_type: Directory
+        path: /var/lib/sss/pipes
+        destination_path: /var/lib/sss/pipes
+      - type: host
+        name: sssd-conf
+        host_type: Directory
+        path: /etc/sssd
+        destination_path: /etc/sssd
+      - type: host
+        name: nsswitch
+        host_type: File
+        path: /etc/nsswitch.conf
+        destination_path: /etc/nsswitch.conf
+      - type: host
+        name: lmod-init
+        host_type: File
+        path: /apps/<%= compute_cluster %>/lmod/lmod.sh
+        destination_path: /etc/profile.d/lmod.sh
+      - type: host
+        name: intel
+        host_type: Directory
+        path: /nfsroot/<%= compute_cluster %>/opt/intel
+        destination_path: /opt/intel
+      - type: host
+        name: apps
+        host_type: Directory
+        path: /apps/<%= compute_cluster %>
+        destination_path: <%= apps_path %>
+    node_selector:
+      cluster: <%= compute_cluster %>
+<% end -%>

--- a/template/after.sh.erb
+++ b/template/after.sh.erb
@@ -1,4 +1,4 @@
-<% if context.cluster != 'kubernetes' -%>
+<% if context.cluster !~ /kubernetes/ -%>
 # Wait for the Jupyter server to start
 echo "Waiting for Jupyter server to open port ${port}..."
 if wait_until_port_used "${host}:${port}" 600; then

--- a/template/after.sh.erb
+++ b/template/after.sh.erb
@@ -1,3 +1,4 @@
+<% if context.cluster != 'kubernetes' -%>
 # Wait for the Jupyter server to start
 echo "Waiting for Jupyter server to open port ${port}..."
 if wait_until_port_used "${host}:${port}" 600; then
@@ -7,3 +8,4 @@ else
   clean_up 1
 fi
 sleep 2
+<% end -%>

--- a/template/before.sh.erb
+++ b/template/before.sh.erb
@@ -1,5 +1,5 @@
 # Export the module function if it exists
-<% if context.cluster == 'kubernetes' -%>
+<% if context.cluster =~ /kubernetes/ -%>
 exec &> >(tee -a "pod.log")
 
 source /etc/profile.d/lmod.sh
@@ -94,7 +94,7 @@ umask 077
 cat > "${CONFIG_FILE}" << EOL
 c.KernelSpecManager.ensure_native_kernel = False
 c.NotebookApp.ip = '*'
-<% if context.cluster == 'kubernetes' -%>
+<% if context.cluster =~ /kubernetes/ -%>
 c.NotebookApp.port = 8080
 c.NotebookApp.base_url = '/node/${HOST_CFG}/${PORT_CFG}/'
 c.NotebookApp.terminado_settings = {'shell_command': ['/bin/bash', '--login', '-i']}

--- a/template/before.sh.erb
+++ b/template/before.sh.erb
@@ -1,5 +1,5 @@
 # Export the module function if it exists
-<% if context.cluster =~ /kubernetes/ -%>
+<% if context.cluster.match?(/kubernetes/) -%>
 exec &> >(tee -a "pod.log")
 
 source /etc/profile.d/lmod.sh
@@ -94,7 +94,7 @@ umask 077
 cat > "${CONFIG_FILE}" << EOL
 c.KernelSpecManager.ensure_native_kernel = False
 c.NotebookApp.ip = '*'
-<% if context.cluster =~ /kubernetes/ -%>
+<% if context.cluster.match?(/kubernetes/) -%>
 c.NotebookApp.port = 8080
 c.NotebookApp.base_url = '/node/${HOST_CFG}/${PORT_CFG}/'
 c.NotebookApp.terminado_settings = {'shell_command': ['/bin/bash', '--login', '-i']}

--- a/template/before.sh.erb
+++ b/template/before.sh.erb
@@ -1,4 +1,13 @@
 # Export the module function if it exists
+<% if context.cluster == 'kubernetes' -%>
+exec &> >(tee -a "pod.log")
+
+source /etc/profile.d/lmod.sh
+
+source /bin/find_host_port
+source /bin/save_passwd_as_secret
+source /bin/create_salt_and_sha1
+<% else -%>
 [[ $(type -t module) == "function" ]] && export -f module
 
 # Find available port to run server on
@@ -8,6 +17,7 @@ port=$(find_port ${host})
 SALT="$(create_passwd 16)"
 password="$(create_passwd 16)"
 PASSWORD_SHA1="$(echo -n "${password}${SALT}" | openssl dgst -sha1 | awk '{print $NF}')"
+<% end -%>
 
 # The `$CONFIG_FILE` environment variable is exported as it is used in the main
 # `script.sh.erb` file when launching the Jupyter server.
@@ -84,10 +94,16 @@ umask 077
 cat > "${CONFIG_FILE}" << EOL
 c.KernelSpecManager.ensure_native_kernel = False
 c.NotebookApp.ip = '*'
+<% if context.cluster == 'kubernetes' -%>
+c.NotebookApp.port = 8080
+c.NotebookApp.base_url = '/node/${HOST_CFG}/${PORT_CFG}/'
+c.NotebookApp.terminado_settings = {'shell_command': ['/bin/bash', '--login', '-i']}
+<% else -%>
 c.NotebookApp.port = ${port}
+c.NotebookApp.base_url = '/node/${host}/${port}/'
+<% end -%>
 c.NotebookApp.port_retries = 0
 c.NotebookApp.password = u'sha1:${SALT}:${PASSWORD_SHA1}'
-c.NotebookApp.base_url = '/node/${host}/${port}/'
 c.NotebookApp.open_browser = False
 c.NotebookApp.allow_origin = '*'
 c.NotebookApp.notebook_dir = '${NOTEBOOK_ROOT}'

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+<% if context.cluster == 'kubernetes' -%>
+exec &> >(tee -a "pod.log")
+<% end -%>
 
 <%-
   require 'pathname'
@@ -78,7 +81,7 @@
       }
   end
 
-  cuda = (context.node_type == "gpu") ? " #{context.cuda_version}" : ""
+  cuda = (context.node_type =~ /gpu/) ? " #{context.cuda_version}" : ""
   wrapper = session.staged_root.join("launch_wrapper.sh")
   wrapper_log = session.staged_root.join("launch_wrapper.log")
 
@@ -226,11 +229,9 @@
     },
   }
 
-  kernels = if context.cluster.eql? 'owens'
+  kernels = if context.cluster.eql? 'owens' || (context.cluster.eql?('kubernetes') && context.node_type =~ /owens/)
               owens_kernels.merge common_kernels
-            elsif context.cluster.eql? 'pitzer'
-              common_kernels
-            elsif context.cluster.eql? 'pitzer-exp'
+            elsif context.cluster.eql? 'pitzer' || (context.cluster.eql?('kubernetes') && context.node_type =~ /pitzer/)
               common_kernels
             else
               {}

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-<% if context.cluster == 'kubernetes' -%>
+<% if context.cluster =~ /kubernetes/ -%>
 exec &> >(tee -a "pod.log")
 <% end -%>
 
@@ -229,9 +229,9 @@ exec &> >(tee -a "pod.log")
     },
   }
 
-  kernels = if context.cluster.eql? 'owens' || (context.cluster.eql?('kubernetes') && context.node_type =~ /owens/)
+  kernels = if context.cluster.eql? 'owens' || (context.cluster =~ /kubernetes/ && context.node_type =~ /owens/)
               owens_kernels.merge common_kernels
-            elsif context.cluster.eql? 'pitzer' || (context.cluster.eql?('kubernetes') && context.node_type =~ /pitzer/)
+            elsif context.cluster.eql? 'pitzer' || (context.cluster =~ /kubernetes/ && context.node_type =~ /pitzer/)
               common_kernels
             else
               {}

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -1,8 +1,4 @@
 #!/usr/bin/env bash
-<% if context.cluster =~ /kubernetes/ -%>
-exec &> >(tee -a "pod.log")
-<% end -%>
-
 <%-
   require 'pathname'
 

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -229,9 +229,13 @@ exec &> >(tee -a "pod.log")
     },
   }
 
-  kernels = if context.cluster.eql? 'owens' || (context.cluster =~ /kubernetes/ && context.node_type =~ /owens/)
+  kernels = if context.cluster.eql? 'owens' || ()
               owens_kernels.merge common_kernels
-            elsif context.cluster.eql? 'pitzer' || (context.cluster =~ /kubernetes/ && context.node_type =~ /pitzer/)
+            elsif context.cluster.match?(/kubernetes/) && context.node_type.match?(/owens/)
+              owens_kernels.merge common_kernels
+            elsif context.cluster.eql? 'pitzer'
+              common_kernels
+            elsif context.cluster.match?(/kubernetes/) && context.node_type.match?(/pitzer/)
               common_kernels
             else
               {}


### PR DESCRIPTION
This relies on several unreleased changes to ondemand.  The changes to support `staged_root` inside the submit template. To make things work like HPC I made memory request be 4GB * number of cores, but adding a field just for Kubernetes to select memory can be done too.