### PR TITLE
Enable JupyterLab extension and add JupyterLab 3.0

### DIFF
--- a/form.yml.erb
+++ b/form.yml.erb
@@ -10,7 +10,7 @@ cluster:
 form:
   - account
   - jupyterlab_switch
-  - jupyterlab_use_extension
+  - use_extension
   - bc_num_hours
   - node_type
   - cuda_version
@@ -25,11 +25,11 @@ attributes:
     help: |
       JupyterLab is the next generation of Jupyter, and is completely compatible with existing Jupyter Notebooks.
 
-  jupyterlab_use_extension:
+  use_extension:
     widget: "check_box"
     label: "Use JupyterLab extensions?"
     help: |
-      Set application directory to home directory. (See [HOWTO] for more detail)
+      Use home directory for JupyterLab application directory. (See [HOWTO] for more detail)
 
       [HOWTO]: https://www.osc.edu/resources/getting_started/howto/howto_use_extensions_with_jupyterlab
 

--- a/form.yml.erb
+++ b/form.yml.erb
@@ -10,7 +10,6 @@ cluster:
 form:
   - account
   - jupyterlab_switch
-  - use_extension
   - bc_num_hours
   - node_type
   - cuda_version
@@ -23,16 +22,7 @@ attributes:
     widget: "check_box"
     label: "Use JupyterLab instead of Jupyter Notebook?"
     help: |
-      JupyterLab is the next generation of Jupyter, and is completely compatible with existing Jupyter Notebooks.
-
-  use_extension:
-    widget: "check_box"
-    label: "Use JupyterLab extensions?"
-    help: |
-      Use home directory for JupyterLab application directory. (See [HOWTO] for more detail)
-
-      [HOWTO]: https://www.osc.edu/resources/getting_started/howto/howto_use_extensions_with_jupyterlab
-
+      JupyterLab is the next generation of Jupyter, and is completely compatible with existing Jupyter Notebooks. 
   num_cores:
     widget: "number_field"
     label: "Number of cores"

--- a/form.yml.erb
+++ b/form.yml.erb
@@ -10,6 +10,7 @@ cluster:
 form:
   - account
   - jupyterlab_switch
+  - jupyterlab_use_extension
   - bc_num_hours
   - node_type
   - cuda_version
@@ -23,6 +24,15 @@ attributes:
     label: "Use JupyterLab instead of Jupyter Notebook?"
     help: |
       JupyterLab is the next generation of Jupyter, and is completely compatible with existing Jupyter Notebooks.
+
+  jupyterlab_use_extension:
+    widget: "check_box"
+    label: "Use JupyterLab extensions?"
+    help: |
+      Set application directory to home directory. (See [HOWTO] for more detail)
+
+      [HOWTO]: https://www.osc.edu/resources/getting_started/howto/howto_use_extensions_with_jupyterlab
+
   num_cores:
     widget: "number_field"
     label: "Number of cores"
@@ -185,6 +195,7 @@ attributes:
     widget: "select"
     label: "JupyterLab Version"
     options:
+      - [ "3.0",  "app_jupyter/3.0.16" ]
       - [ "2.1",  "app_jupyter/2.1.4" ]
       - [ "1.2",  "app_jupyter/1.2.16" ]
       - [ "0.35", "app_jupyter/0.35.6" ]

--- a/info.md.erb
+++ b/info.md.erb
@@ -1,18 +1,23 @@
 <%
-  jupyterlab_version = JSON.parse(user_defined_context_file.read)['version'].split('/').last
-  jupyterlab_switch = JSON.parse(user_defined_context_file.read)['jupyterlab_switch']
-  jupyterlab_use_extension = JSON.parse(user_defined_context_file.read)['jupyterlab_use_extension']
-  jupyterlab_extension_enabled = false
-  if jupyterlab_switch == "1" and jupyterlab_use_extension == "1" and jupyterlab_version.split('.').first.to_i > 0
-    jupyterlab_extension_enabled = true
+  begin
+    data = JSON.parse(user_defined_context_file.read)
+  rescue
+    data = {}
+  end
+  version = data['version'].split('/').last
+  switch = data['jupyterlab_switch'].to_s
+  use_extension = data['jupyterlab_use_extension'].to_s
+  extension_enabled = false
+  if switch == "1" and use_extension == "1" and version.split('.').first.to_i > 0
+    extension_enabled = true
   end
 %>
 **Information:**
 
-- JupyterLab version: <%= jupyterlab_version %>
-- Use JupyterLab: <%= jupyterlab_switch == "1" ? "Yes" : "No" %>
-- JupyterLab extensions enabled: <%=  jupyterlab_extension_enabled ? "Yes" : "No" %>
-<%- if jupyterlab_extension_enabled -%>
-- JupyterLab application directory: $HOME/.jupyter/lab/<%= jupyterlab_version.split('/').last.split('.')[0..1].join('.') %>
+- JupyterLab version: <%= version %>
+- Use JupyterLab: <%= switch == "1" ? "Yes" : "No" %>
+- JupyterLab extensions enabled: <%= extension_enabled ? "Yes" : "No" %>
+<%- if extension_enabled -%>
+- JupyterLab application directory: <%= ENV['HOME'] %>/.jupyter/lab/<%= version.split('/').last.split('.')[0..1].join('.') %>
 <%- end -%>
 

--- a/info.md.erb
+++ b/info.md.erb
@@ -1,0 +1,18 @@
+<%
+  jupyterlab_version = JSON.parse(user_defined_context_file.read)['version'].split('/').last
+  jupyterlab_switch = JSON.parse(user_defined_context_file.read)['jupyterlab_switch']
+  jupyterlab_use_extension = JSON.parse(user_defined_context_file.read)['jupyterlab_use_extension']
+  jupyterlab_extension_enabled = false
+  if jupyterlab_switch == "1" and jupyterlab_use_extension == "1" and jupyterlab_version.split('.').first.to_i > 0
+    jupyterlab_extension_enabled = true
+  end
+%>
+**Information:**
+
+- JupyterLab version: <%= jupyterlab_version %>
+- Use JupyterLab: <%= jupyterlab_switch == "1" ? "Yes" : "No" %>
+- JupyterLab extensions enabled: <%=  jupyterlab_extension_enabled ? "Yes" : "No" %>
+<%- if jupyterlab_extension_enabled -%>
+- JupyterLab application directory: $HOME/.jupyter/lab/<%= jupyterlab_version.split('/').last.split('.')[0..1].join('.') %>
+<%- end -%>
+

--- a/info.md.erb
+++ b/info.md.erb
@@ -10,16 +10,16 @@
   use_extension = data['use_extension'].to_s
   classroom = data['classroom'].to_s
 
-  def jupyterlab_dir
+  def jupyterlab_dir(version)
     base = "#{OodSupport::User.new.dir}/.juypter/lab"
-    match = JSON.parse(user_defined_context_file.read)['version'].to_s.match('app_jupyter/(?<majmin>\d+\.\d+)')
-    majmin = if !match.nil? && match.named_captures.key?('majmin')
-               match[:majmin]
-             else
-               'unknown'
-             end
+    match = version.match('app_jupyter/(?<maj_min_version>\d+\.\d+)')
+    maj_min_version = if !match.nil? && match.named_captures.key?('maj_min_version')
+                        match[:maj_min_version]
+                      else
+                        'unknown'
+                      end
 
-    "#{base}/#{majmin}"
+    "#{base}/#{maj_min_version}"
   end
 %>
 **Information:**
@@ -29,7 +29,7 @@
 <%- if classroom != "1" -%>
 - JupyterLab extensions enabled: <%= use_extension == "1" ? "Yes" : "No" %>
 <% if use_extension == "1" -%>
-- JupyterLab application directory: <%= jupyterlab_dir %>
+- JupyterLab application directory: <%= jupyterlab_dir(version) %>
 <%- end -%>
 <%- end -%>
 

--- a/info.md.erb
+++ b/info.md.erb
@@ -7,7 +7,6 @@
 
   version = data['version'].to_s
   switch = data['jupyterlab_switch'].to_s
-  use_extension = data['use_extension'].to_s
   classroom = data['classroom'].to_s
 
   def jupyterlab_dir(version)
@@ -25,11 +24,7 @@
 **Information:**
 
 - JupyterLab version: <%= version.split('/').last %>
-- Use JupyterLab: <%= switch == "1" ? "Yes" : "No" %>
-<%- if classroom != "1" -%>
-- JupyterLab extensions enabled: <%= use_extension == "1" ? "Yes" : "No" %>
-<% if use_extension == "1" -%>
+- Use Jupyter Notebook: <%= switch == "1" ? "No" : "Yes" %>
+<%- if switch == "1" and classroom != "1" -%>
 - JupyterLab application directory: <%= jupyterlab_dir(version) %>
 <%- end -%>
-<%- end -%>
-

--- a/info.md.erb
+++ b/info.md.erb
@@ -11,7 +11,7 @@
   classroom = data['classroom'].to_s
 
   def jupyterlab_dir(version)
-    base = "#{OodSupport::User.new.dir}/.juypter/lab"
+    base = "#{OodSupport::User.new.dir}/.jupyter/lab"
     match = version.match('app_jupyter/(?<maj_min_version>\d+\.\d+)')
     maj_min_version = if !match.nil? && match.named_captures.key?('maj_min_version')
                         match[:maj_min_version]

--- a/info.md.erb
+++ b/info.md.erb
@@ -4,20 +4,32 @@
   rescue
     data = {}
   end
-  version = data['version'].split('/').last
+
+  version = data['version'].to_s
   switch = data['jupyterlab_switch'].to_s
-  use_extension = data['jupyterlab_use_extension'].to_s
-  extension_enabled = false
-  if switch == "1" and use_extension == "1" and version.split('.').first.to_i > 0
-    extension_enabled = true
+  use_extension = data['use_extension'].to_s
+  classroom = data['classroom'].to_s
+
+  def jupyterlab_dir
+    base = "#{OodSupport::User.new.dir}/.juypter/lab"
+    match = JSON.parse(user_defined_context_file.read)['version'].to_s.match('app_jupyter/(?<majmin>\d+\.\d+)')
+    majmin = if !match.nil? && match.named_captures.key?('majmin')
+               match[:majmin]
+             else
+               'unknown'
+             end
+
+    "#{base}/#{majmin}"
   end
 %>
 **Information:**
 
-- JupyterLab version: <%= version %>
+- JupyterLab version: <%= version.split('/').last %>
 - Use JupyterLab: <%= switch == "1" ? "Yes" : "No" %>
-- JupyterLab extensions enabled: <%= extension_enabled ? "Yes" : "No" %>
-<%- if extension_enabled -%>
-- JupyterLab application directory: <%= ENV['HOME'] %>/.jupyter/lab/<%= version.split('/').last.split('.')[0..1].join('.') %>
+<%- if classroom != "1" -%>
+- JupyterLab extensions enabled: <%= use_extension == "1" ? "Yes" : "No" %>
+<% if use_extension == "1" -%>
+- JupyterLab application directory: <%= jupyterlab_dir %>
+<%- end -%>
 <%- end -%>
 

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -363,11 +363,13 @@ jupyter kernelspec list
 echo "TTT - $(date)"
 
 # Setup custom Application directory so user can manage extensions
-<%- if context.use_extension == "1" and context.classroom != "1" -%>
-export JUPYTERLAB_DIR=<%= jupyterlab_dir %>
-if [ ! -d $JUPYTERLAB_DIR ] || [ -z "$(ls -A $JUPYTERLAB_DIR)" ] ; then
-  mkdir -p $JUPYTERLAB_DIR
-  cp -r ${OSC_APP_JUPYTER_DIR}/share/jupyter/lab/*  ${JUPYTERLAB_DIR}/
+<%- if context.classroom != "1" -%>
+if [ -z "$JUPYTERLAB_DIR" ] ; then
+  export JUPYTERLAB_DIR=<%= jupyterlab_dir %>
+  if [ ! -d $JUPYTERLAB_DIR ] || [ -z "$(ls -A $JUPYTERLAB_DIR)" ] ; then
+    mkdir -p $JUPYTERLAB_DIR
+    cp -r ${OSC_APP_JUPYTER_DIR}/share/jupyter/lab/*  ${JUPYTERLAB_DIR}/
+  fi
 fi
 <%- end -%>
 

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -3,11 +3,17 @@
 <%-
   require 'pathname'
 
-  # Check if we can enable JupyterLab extension
-  extension_enabled = false
-  version = context.version.split('/').last
-  if context.jupyterlab_switch == "1" and context.jupyterlab_use_extension == "1" and version.split('.').first.to_i > 0
-    extension_enabled = true
+  # @returns $HOME/.jupyter/lab/major_minor_version
+  def jupyterlab_dir
+    base = "#{OodSupport::User.new.dir}/.juypter/lab"
+    match = context.version.match('app_jupyter/(?<majmin>\d+\.\d+)')
+    majmin = if !match.nil? && match.named_captures.key?('majmin')
+               match[:majmin]
+             else
+               'unknown'
+             end
+
+    "#{base}/#{majmin}"
   end
 
   # The list of Julia installations that LMod knows about
@@ -357,8 +363,8 @@ jupyter kernelspec list
 echo "TTT - $(date)"
 
 # Setup custom Application directory so user can manage extensions
-<%- if extension_enabled -%>
-export JUPYTERLAB_DIR=$HOME/.jupyter/lab/<%= context.version.split('/').last.split('.')[0..1].join('.') %>
+<%- if context.use_extension == "1" and context.classroom != "1" -%>
+export JUPYTERLAB_DIR=<%= jupyterlab_dir %>
 if [ ! -d $JUPYTERLAB_DIR ] || [ -z "$(ls -A $JUPYTERLAB_DIR)" ] ; then
   mkdir -p $JUPYTERLAB_DIR
   cp -r ${OSC_APP_JUPYTER_DIR}/share/jupyter/lab/*  ${JUPYTERLAB_DIR}/

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -5,7 +5,7 @@
 
   # @returns $HOME/.jupyter/lab/major_minor_version
   def jupyterlab_dir
-    base = "#{OodSupport::User.new.dir}/.juypter/lab"
+    base = "#{OodSupport::User.new.dir}/.jupyter/lab"
     match = context.version.match('app_jupyter/(?<maj_min_version>\d+\.\d+)')
     maj_min_version = if !match.nil? && match.named_captures.key?('maj_min_version')
                         match[:maj_min_version]

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -4,10 +4,10 @@
   require 'pathname'
 
   # Check if we can enable JupyterLab extension
-  jupyterlab_extension_enabled = false
-  jupyterlab_version = context.version.split('/').last
-  if context.jupyterlab_switch == "1" and context.jupyterlab_use_extension == "1" and jupyterlab_version.split('.').first.to_i > 0
-    jupyterlab_extension_enabled = true
+  extension_enabled = false
+  version = context.version.split('/').last
+  if context.jupyterlab_switch == "1" and context.jupyterlab_use_extension == "1" and version.split('.').first.to_i > 0
+    extension_enabled = true
   end
 
   # The list of Julia installations that LMod knows about
@@ -357,7 +357,7 @@ jupyter kernelspec list
 echo "TTT - $(date)"
 
 # Setup custom Application directory so user can manage extensions
-<%- if jupyterlab_extension_enabled -%>
+<%- if extension_enabled -%>
 export JUPYTERLAB_DIR=$HOME/.jupyter/lab/<%= context.version.split('/').last.split('.')[0..1].join('.') %>
 if [ ! -d $JUPYTERLAB_DIR ] || [ -z "$(ls -A $JUPYTERLAB_DIR)" ] ; then
   mkdir -p $JUPYTERLAB_DIR

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -6,14 +6,14 @@
   # @returns $HOME/.jupyter/lab/major_minor_version
   def jupyterlab_dir
     base = "#{OodSupport::User.new.dir}/.juypter/lab"
-    match = context.version.match('app_jupyter/(?<majmin>\d+\.\d+)')
-    majmin = if !match.nil? && match.named_captures.key?('majmin')
-               match[:majmin]
-             else
-               'unknown'
-             end
+    match = context.version.match('app_jupyter/(?<maj_min_version>\d+\.\d+)')
+    maj_min_version = if !match.nil? && match.named_captures.key?('maj_min_version')
+                        match[:maj_min_version]
+		      else
+		        'unknown'
+		      end
 
-    "#{base}/#{majmin}"
+    "#{base}/#{maj_min_version}"
   end
 
   # The list of Julia installations that LMod knows about

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -3,6 +3,13 @@
 <%-
   require 'pathname'
 
+  # Check if we can enable JupyterLab extension
+  jupyterlab_extension_enabled = false
+  jupyterlab_version = context.version.split('/').last
+  if context.jupyterlab_switch == "1" and context.jupyterlab_use_extension == "1" and jupyterlab_version.split('.').first.to_i > 0
+    jupyterlab_extension_enabled = true
+  end
+
   # The list of Julia installations that LMod knows about
   # @returns [[major_minor_version, "lmod_load_string"], ["0.6", "julia/0.6.4"]]
   def get_lmod_julia_versions
@@ -348,6 +355,15 @@ set -x
 jupyter kernelspec list
 { set +x; } 2>/dev/null
 echo "TTT - $(date)"
+
+# Setup custom Application directory so user can manage extensions
+<%- if jupyterlab_extension_enabled -%>
+export JUPYTERLAB_DIR=$HOME/.jupyter/lab/<%= context.version.split('/').last.split('.')[0..1].join('.') %>
+if [ ! -d $JUPYTERLAB_DIR ] || [ -z "$(ls -A $JUPYTERLAB_DIR)" ] ; then
+  mkdir -p $JUPYTERLAB_DIR
+  cp -r ${OSC_APP_JUPYTER_DIR}/share/jupyter/lab/*  ${JUPYTERLAB_DIR}/
+fi
+<%- end -%>
 
 # Launch the Jupyter server
 set -x


### PR DESCRIPTION
1. Add `app_jupyter/3.0.16` to the form
2. Add an option for enabling  user-level JupyterLab extension management
3. Add info card to display JupyterLab version and the options enabled. 