### PR TITLE
Avoid errors for class.osc.edu

### DIFF
--- a/form.js
+++ b/form.js
@@ -197,12 +197,9 @@ function toggle_cuda_version_visibility(selected_node_type) {
 /**
  * Toggle the visibility of the email on started field
  */
-function toggle_email_on_started(selected_cluster) {
-  if(selected_cluster === undefined) {
-    return;
-  }
+function toggle_email_on_started() {
   const element = $('#batch_connect_session_context_bc_email_on_started');
-  const supported = !selected_cluster.includes('kubernetes');
+  const supported = !current_cluster_capitalized().includes('Kubernetes');
 
   toggle_visibility_of_form_group(element, supported);
 }
@@ -238,7 +235,7 @@ function cluster_change_handler(event) {
   toggle_options("batch_connect_session_context_cuda_version");
   toggle_options("batch_connect_session_context_node_type");
   fix_num_cores(event);
-  toggle_email_on_started(event.target.value);
+  toggle_email_on_started();
 }
 
 /**
@@ -250,9 +247,7 @@ fix_num_cores({ target: document.querySelector('#batch_connect_session_node_type
 toggle_cuda_version_visibility(
   $('#batch_connect_session_context_node_type option:selected').val()
 );
-toggle_email_on_started(
-  $('#batch_connect_session_context_cluster option:selected').val()
-);
+toggle_email_on_started();
 toggle_options("batch_connect_session_context_cuda_version");
 toggle_options("batch_connect_session_context_node_type");
 

--- a/form.js
+++ b/form.js
@@ -198,6 +198,9 @@ function toggle_cuda_version_visibility(selected_node_type) {
  * Toggle the visibility of the email on started field
  */
 function toggle_email_on_started(selected_cluster) {
+  if(selected_cluster === undefined) {
+    return;
+  }
   const element = $('#batch_connect_session_context_bc_email_on_started');
   const supported = !selected_cluster.includes('kubernetes');
 


### PR DESCRIPTION
I saw this in javascript console when using `local` directory forms like for class.osc.edu:

```
new:695 Uncaught TypeError: Cannot read property 'includes' of undefined
    at toggle_email_on_started (new:695)
    at new:829
    at new:840
```