### PR TITLE
add kernels back and add an info file for upcoming updates

### DIFF
--- a/info.md.erb
+++ b/info.md.erb
@@ -1,0 +1,8 @@
+<span style="font-size:2.5em;">Upcoming Jupyter Updates</span>
+
+1. The Julia kernels 0.5.1 and Julia 0.6.4 are being removed.
+2. Julia kernels >= 1.0 are not automatically installed. 
+    See [the documentation on installing Julia kernels](https://www.osc.edu/resources/available_software/software_list/julia#install_julia_kernel).
+3. Python kernels for Conda environments created using Python 2.7, 3.5 and 3.6 on Owens are not automatically installed. 
+   See [the documentation on conda driven python kernels](https://www.osc.edu/resources/getting_started/howto/howto_use_a_condavirtual_environment_with_jupyter).
+

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -1,6 +1,261 @@
 #!/usr/bin/env bash
 <%-
   require 'pathname'
+
+  # The list of Julia installations that LMod knows about
+  # @returns [[major_minor_version, "lmod_load_string"], ["0.6", "julia/0.6.4"]]
+  def get_lmod_julia_versions
+      [
+        ["0.5", "0.5.1"],
+        ["0.6", "0.6.4"],
+        ["1.0", "1.0.5"],
+        ["1.1", "1.1.1"],
+        ["1.3", "1.3.1"],
+        ["1.5", "1.5.3"]
+      ]
+  end
+
+  # @returns [[major_minor_version, kernel_version], ["1.0", "1.20.0"]]
+  def get_active_user_ijulia_kernel_versions
+      user_julia_envs = Pathname.new("~/.julia/environments/").expand_path
+
+      if ! user_julia_envs.exist?
+          []
+      else
+          user_julia_envs.children.select do |child|
+              child.directory? && child.to_s.match?(/v\d+\.\d+/) && child.join('Manifest.toml').exist?
+          end.map do |child|
+              [
+                  child.basename.to_s.gsub('v', ''),
+                  child.join('Manifest.toml').read.match(/\[\[IJulia\]\].+?version\s*=\s*"(?<version>\d+\.\d+\.\d+)"\n/m)
+              ]
+          end.select do |pair|
+              pair[-1]
+          end.map do |pair|
+              pair[-1] = pair[-1][:version]
+              pair
+          end
+      end
+  end
+
+  # @returns [[kernel_version, path_to_kernel], ["1.19.0", #<Pathname:/users/PZS0710/zyou/.julia/packages/IJulia/cwvsj/src/kernel.jl>]]
+  def get_installed_user_ijulia_kernels
+      ijulia_installation_root = Pathname.new("~/.julia/packages/IJulia").expand_path
+
+      if ! ijulia_installation_root.exist?
+          []
+      else
+          ijulia_installation_root.children.select do |child|
+              child.join('Project.toml').exist?
+          end.map do |child|
+              [
+                  child.join('Project.toml').read.match(/version\s*=\s*"(?<version>\d+\.\d+\.\d+)"/)[:version],
+                  child.join('src/kernel.jl').to_s
+              ]
+          end
+      end
+  end
+
+  def kernel_hash(
+      cuda:, installation:, lmod_version:, wrapper:
+  )
+      {
+        display_name: "User Defined Julia #{lmod_version}" + ((cuda.empty?) ? "" : " [#{cuda}]"),
+        language: "julia",
+        argv: [
+          wrapper,
+          "julia",
+          "-i",
+          "--startup-file=yes",
+          "--color=yes",
+          installation,
+          "{connection_file}"
+        ],
+        env: {
+          MODULES: "xalt/latest julia/#{lmod_version} #{cuda}"
+        }
+      }
+  end
+
+  cuda = (context.node_type =~ /gpu/) ? " #{context.cuda_version}" : ""
+  wrapper = session.staged_root.join("launch_wrapper.sh")
+  wrapper_log = session.staged_root.join("launch_wrapper.log")
+
+  # kernels common to all clusters. it just happens that pitzer is common to both
+  common_kernels = {
+    python36conda: {
+      display_name: "Python 3.6 (Conda 5.2) [python/3.6-conda5.2#{cuda}]",
+      language: "python",
+      argv: [
+        wrapper,
+        "python",
+        "-m",
+        "ipykernel_launcher",
+        "-f",
+        "{connection_file}"
+      ],
+      env: {
+        MODULES: "xalt/latest python/3.6-conda5.2#{cuda}"
+      }
+    },
+    python27conda: {
+      display_name: "Python 2.7 (Conda 5.2) [python/2.7-conda5.2#{cuda}]",
+      language: "python",
+      argv: [
+        wrapper,
+        "python",
+        "-m",
+        "ipykernel",
+        "-f",
+        "{connection_file}"
+      ],
+      env: {
+        MODULES: "xalt/latest python/2.7-conda5.2#{cuda}"
+      }
+    },
+    python37_2019_10: {
+      display_name: "Python 3.7-2019.10 [python/3.7-2019.10#{cuda}]",
+      language: "python",
+      argv: [
+        wrapper,
+        "python",
+        "-m",
+        "ipykernel",
+        "-f",
+        "{connection_file}"
+      ],
+      env: {
+        MODULES: "xalt/latest python/3.7-2019.10#{cuda}"
+      }
+    }
+  }
+
+  owens_kernels = {
+    python36: {
+      display_name: "Python 3.6 [python/3.6#{cuda}]",
+      language: "python",
+      argv: [
+        wrapper,
+        "python",
+        "-m",
+        "ipykernel_launcher",
+        "-f",
+        "{connection_file}"
+      ],
+      env: {
+        MODULES: "xalt/latest python/3.6#{cuda}"
+      }
+    },
+    python35: {
+      display_name: "Python 3.5 [python/3.5#{cuda}]",
+      language: "python",
+      argv: [
+        wrapper,
+        "python",
+        "-m",
+        "ipykernel",
+        "-f",
+        "{connection_file}"
+      ],
+      env: {
+        MODULES: "xalt/latest python/3.5#{cuda}"
+      }
+    },
+    python27: {
+      display_name: "Python 2.7 [python/2.7#{cuda}]",
+      language: "python",
+      argv: [
+        wrapper,
+        "python",
+        "-m",
+        "ipykernel",
+        "-f",
+        "{connection_file}"
+      ],
+      env: {
+        MODULES: "xalt/latest python/2.7 #{cuda}"
+      }
+    },
+    python27conda: {
+      display_name: "Python 2.7 (Conda 5.2) [python/2.7#{cuda}]",
+      language: "python",
+      argv: [
+        wrapper,
+        "python",
+        "-m",
+        "ipykernel",
+        "-f",
+        "{connection_file}"
+      ],
+      env: {
+        MODULES: "xalt/latest python/2.7-conda5.2#{cuda}"
+      }
+    },
+    julia051: {
+      display_name: "Julia 0.5.1 [julia/0.5.1#{cuda}]",
+      language: "julia",
+      argv: [
+        wrapper,
+        "julia",
+        "-i",
+        "--startup-file=yes",
+        "--color=yes",
+        "/usr/local/julia/0.5.1/share/julia/site/v0.5/IJulia/src/kernel.jl",
+        "{connection_file}"
+      ],
+      env: {
+        MODULES: "xalt/latest julia/0.5.1#{cuda}"
+      }
+    },
+    julia064: {
+      display_name: "Julia 0.6.4 [julia/0.6.4#{cuda}]",
+      language: "julia",
+      argv: [
+        wrapper,
+        "julia",
+        "-i",
+        "--startup-file=yes",
+        "--color=yes",
+        "/usr/local/julia/0.6.4/site/v0.6/IJulia/src/kernel.jl",
+        "{connection_file}"
+      ],
+      env: {
+        MODULES: "xalt/latest julia/0.6.4 #{cuda}"
+      },
+    },
+  }
+
+  kernels = if context.cluster.eql? 'owens' || ()
+              owens_kernels.merge common_kernels
+            elsif context.cluster.match?(/kubernetes/) && context.node_type.match?(/owens/)
+              owens_kernels.merge common_kernels
+            elsif context.cluster.eql? 'pitzer'
+              common_kernels
+            elsif context.cluster.match?(/kubernetes/) && context.node_type.match?(/pitzer/)
+              common_kernels
+            else
+              {}
+            end
+
+  kernels.tap do |hsh|
+    # Any existing Julia kernelspec may be clobbered if the user has their own version of that kernel installed
+    lmod_julia_versions = Hash[get_lmod_julia_versions]
+    installed_user_ijulia_kernels = Hash[get_installed_user_ijulia_kernels]
+
+    get_active_user_ijulia_kernel_versions.each do |maj_min_ver, kernel_version|
+        lmod_version = lmod_julia_versions[maj_min_ver]
+
+        next unless lmod_version
+        next unless installed_user_ijulia_kernels[kernel_version]
+
+        hsh["julia#{lmod_version.gsub('.', '')}".to_sym] = kernel_hash(
+            cuda: cuda,
+            installation: installed_user_ijulia_kernels[kernel_version],
+            lmod_version: lmod_version,
+            wrapper: wrapper
+        )
+    end
+  end
 -%>
 
 echo "Starting main script..."
@@ -13,17 +268,80 @@ echo "TTT - $(date)"
 # Clean the environment
 module purge
 
-# Required modules
-module load xalt/latest <%= context.cuda_version %>
+# Create launcher wrapper
+echo "Creating launcher wrapper script..."
+(
+umask 077
+sed 's/^ \{2\}//' > "<%= wrapper %>" << EOL
+  #!/usr/bin/env bash
+
+  # Log all output from this script
+  exec &>>"<%= wrapper_log %>"
+
+  # Load the required environment
+  module purge
+  module load xalt/latest \${MODULES}
+  module list
+
+  # Launch the original command
+  set -x
+  exec "\${@}"
+EOL
+)
+chmod 700 "<%= wrapper %>"
+echo "TTT - $(date)"
+
+
+<%- unless context.classroom == "1" -%>
+# Create custom Jupyter kernels
+echo "Creating custom Jupyter kernels..."
+export JUPYTER_PATH="${PWD}/share/jupyter"
+<%- kernels.each do |name, kernel| -%>
+<%- path = "${JUPYTER_PATH}/kernels/sys_#{name}" -%>
+mkdir -p "<%= path %>"
+cp "${PWD}/assets/<%= name.to_s.gsub(/\d|_/, "") %>"/* "<%= path %>/."
+(
+umask 077
+cat > "<%= path %>/kernel.json" << EOL
+<%= JSON.pretty_generate kernel %>
+EOL
+)
+<%- end -%>
+<%- end -%>
+echo "TTT - $(date)"
+
+# Create user-created Conda env Jupyter kernels
+echo "Creating custom Jupyter kernels from user-created Conda environments..."
+for dir in "${HOME}/.conda/envs"/*/ "${HOME}/envs"/*/ ; do
+  (
+  umask 077
+  set -e
+  KERNEL_NAME="$(basename "${dir}")"
+  KERNEL_PATH="~${dir#${HOME}}"
+  [[ -x "${dir}bin/activate" ]] || exit 0
+  echo "Creating kernel for ${dir}..."
+  source "${dir}bin/activate" "${dir}"
+  set -x
+  if [[ "$(conda list -f --json ipykernel)" == "[]" ]]; then
+    CONDA_PKGS_DIRS="$(mktemp -d)" conda install --yes --quiet --no-update-deps ipykernel
+  fi
+  python \
+    -m ipykernel \
+      install \
+      --name "conda_${KERNEL_NAME}" \
+      --display-name "${KERNEL_NAME} [${KERNEL_PATH}]" \
+      --prefix "${PWD}"
+  ) &
+done
+wait
+echo "TTT - $(date)"
 
 # Set working directory to notebook root directory
 cd "${NOTEBOOK_ROOT}"
 
 # Setup Jupyter environment
-module load project/ondemand <%= context.version %>
+module load ondemand/project xalt/latest <%= context.version %>
 module list
-export JUPYTER_PATH="${PWD}/share/jupyter:${OSC_JUPYTER_PATH}"
-
 echo "TTT - $(date)"
 
 # List available kernels for debugging purposes


### PR DESCRIPTION
add kernels back and add an info file for upcoming updates.  Instead of releasing v22 out of master, we're going to release from this branch `release-v22` so that we don't have to revert kernels in the mainline.