### PR TITLE
Option for root directory

### DIFF
--- a/form.yml
+++ b/form.yml
@@ -9,6 +9,7 @@ cluster:
   - "cardinal"
 form:
   - auto_accounts
+  - root_dir
   - mode
   - bc_num_hours
   - node_type
@@ -20,6 +21,12 @@ form:
 attributes:
   auto_modules_app_jupyter:
     default: false
+  root_dir:
+    widget: "path_selector"
+    label: "Root Directory"
+    help: |
+      If no root directory is provided, 
+      or the directory is invalid, Jupyter will start in `$HOME`
   mode:
     widget: "radio"
     value: "1"

--- a/template/before.sh.erb
+++ b/template/before.sh.erb
@@ -93,6 +93,12 @@ module purge
 export JUPYTERLAB_WORKSPACES_DIR=$PWD
 export jupyter_api="$JUPYTER_API"
 
+<%- if context.root_dir != "" -%>
+if [[ -r <%= context.root_dir %> ]]; then
+  NOTEBOOK_ROOT=<%= context.root_dir %>
+fi
+<%- end -%>
+
 # Notebook root directory
 export NOTEBOOK_ROOT="${NOTEBOOK_ROOT:-${HOME}}"
 


### PR DESCRIPTION
Currently there is no known way to change the root directory that Jupyter starts in using the OnDemand interface. This presents issues when a user is trying to access anywhere other than their `$HOME` directory.

This PR allows users to choose the directory that Jupyter starts in. They must have read access to the chosen directory, or else the program will default to starting Jupyter in `$HOME`. If no directory is provided, then `$HOME` will be the default.