### PR TITLE
Allow for choice of notebook root

### DIFF
--- a/form.yml
+++ b/form.yml
@@ -10,6 +10,7 @@ cluster:
 form:
   - auto_accounts
   - mode
+  - working_dir
   - bc_num_hours
   - node_type
   - gpus
@@ -70,6 +71,12 @@ attributes:
     options:
       - ["Jupyter Lab", "1"]
       - ["Jupyter Notebook", "0"]
+  working_dir:
+    widget: "path_selector"
+    label: "Root Directory"
+    data-target-file-type: dirs  # Valid values are: files, dirs, or both
+    readonly: false
+    help: "Select your project directory; defaults to $HOME"
   num_cores:
     widget: "number_field"
     label: "Number of cores"

--- a/manifest.yml
+++ b/manifest.yml
@@ -4,11 +4,12 @@ category: Interactive Apps
 subcategory: Servers
 role: batch_connect
 description: |
-  This app will launch a [Jupyter] server using [Python] on the [Ascend], [Owens] or
-  [Pitzer] clusters.
+  Launch a [Jupyter] server with [Python] on [Cardinal], [Ascend], or [Pitzer].
+  Check the [Changelog] for the recent updates.
 
   [Jupyter]: https://jupyter.org/
   [Python]: https://www.python.org/
-  [Owens]: https://www.osc.edu/resources/technical_support/supercomputers/owens
+  [Cardinal]: https://www.osc.edu/resources/technical_support/supercomputers/cardinal
+  [Ascend]: https://www.osc.edu/resources/technical_support/supercomputers/ascend
   [Pitzer]: https://www.osc.edu/resources/technical_support/supercomputers/pitzer
-  [Ascend]: https://www.osc.edu/vocabulary/systems/ascend
+  [Changelog]: https://www.osc.edu/resources/technical_support/hpc_changelog?keys=jupyter

--- a/template/before.sh.erb
+++ b/template/before.sh.erb
@@ -8,6 +8,7 @@ source /bin/find_host_port
 source /bin/save_passwd_as_secret
 source /bin/create_salt_and_sha1
 <% else -%>
+
 [[ $(type -t module) == "function" ]] && export -f module
 
 # Find available port to run server on
@@ -49,7 +50,7 @@ export JUPYTERLAB_WORKSPACES_DIR=$PWD
 export jupyter_api="$JUPYTER_API"
 
 # Notebook root directory
-export NOTEBOOK_ROOT="${NOTEBOOK_ROOT:-${HOME}}"
+export NOTEBOOK_ROOT="<%= Pathname.new(context.working_dir) %>"
 
 # Generate Jupyter configuration file with secure file permissions
 (

--- a/template/before.sh.erb
+++ b/template/before.sh.erb
@@ -50,8 +50,13 @@ export JUPYTERLAB_WORKSPACES_DIR=$PWD
 export jupyter_api="$JUPYTER_API"
 
 # Notebook root directory
-USER_SELECT_ROOT="<%= Pathname.new(context.working_dir) %>"
-export NOTEBOOK_ROOT="${USER_SELECT_ROOT:-$HOME}"
+working_dir="<%= Pathname.new(context.working_dir) %>"
+USER_SELECT_ROOT="${working_dir:-$HOME}"
+if [[ -r "$USER_SELECT_ROOT" ]]; then
+  export NOTEBOOK_ROOT="$USER_SELECT_ROOT"
+else
+  export NOTEBOOK_ROOT="$HOME"
+fi
 
 # Generate Jupyter configuration file with secure file permissions
 (

--- a/template/before.sh.erb
+++ b/template/before.sh.erb
@@ -50,7 +50,8 @@ export JUPYTERLAB_WORKSPACES_DIR=$PWD
 export jupyter_api="$JUPYTER_API"
 
 # Notebook root directory
-export NOTEBOOK_ROOT="<%= Pathname.new(context.working_dir) %>"
+USER_SELECT_ROOT="<%= Pathname.new(context.working_dir) %>"
+export NOTEBOOK_ROOT="${USER_SELECT_ROOT:-$HOME}"
 
 # Generate Jupyter configuration file with secure file permissions
 (


### PR DESCRIPTION
Use `path_selector` to allow users to select the root directory for their notebooks.